### PR TITLE
Guard server_control recursive execution

### DIFF
--- a/mods/oni_mcp/Tools/Legacy/Impl/Server/AgentProgramTools.cs
+++ b/mods/oni_mcp/Tools/Legacy/Impl/Server/AgentProgramTools.cs
@@ -269,6 +269,8 @@ namespace OniMcp.Tools
                 if (TryResolveCallShape(stmt, out toolName, out ignored, out ignoredSave))
                 {
                     referencedTools.Add(toolName);
+                    if (IsProgramCall(toolName, ignored))
+                        throw new AgentProgramException(path + " agent program cannot call itself");
                     McpTool tool;
                     if (!OniToolRegistry.TryGetTool(toolName, out tool))
                         throw new AgentProgramException(path + " references unknown tool: " + toolName);
@@ -416,15 +418,12 @@ namespace OniMcp.Tools
             private void ExecuteCall(string toolName, JObject rawArgs, string saveAs, bool continueOnError, string path)
             {
                 referencedTools.Add(toolName);
-                if (string.Equals(toolName, ToolName, StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(toolName, "agent_script_run", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(toolName, "agent_flow_execute", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(toolName, "agent_program_run", StringComparison.OrdinalIgnoreCase))
+                JObject args = ResolveObject(rawArgs);
+                if (IsProgramCall(toolName, args))
                 {
                     throw new AgentProgramException("agent program cannot call itself");
                 }
 
-                JObject args = ResolveObject(rawArgs);
                 if (toolName == "world_cell_info" && (args["x"] == null || args["y"] == null))
                     FillCurrentPointerCell(args);
 
@@ -456,6 +455,18 @@ namespace OniMcp.Tools
 
                 if ((result == null || result.IsError) && !continueOnError)
                     throw new AgentProgramException("tool call failed at " + path + ": " + toolName + " -> " + text);
+            }
+
+            private static bool IsProgramCall(string toolName, JObject arguments)
+            {
+                McpTool tool;
+                if (OniToolRegistry.TryGetTool(toolName, out tool)
+                    && string.Equals(tool.Name, ToolName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                return ServerTools.IsServerControlDomainCall(toolName, arguments, "program", "agent_program", "flow", "script");
             }
 
             private void FillCurrentPointerCell(JObject args)

--- a/mods/oni_mcp/Tools/Legacy/Impl/Server/ServerTools.cs
+++ b/mods/oni_mcp/Tools/Legacy/Impl/Server/ServerTools.cs
@@ -13,11 +13,13 @@ namespace OniMcp.Tools
 {
     public static class ServerTools
     {
+        internal const string ToolName = "server_control";
+
         public static McpTool ControlServer()
         {
             return new McpTool
             {
-                Name = "server_control",
+                Name = ToolName,
                 Group = "server",
                 Mode = "read/execute",
                 Risk = "medium",
@@ -93,6 +95,25 @@ namespace OniMcp.Tools
                     return CallToolResult.Error("domain must be diagnostics, client_request, catalog, batch, or program");
                 }
             };
+        }
+
+        internal static bool IsServerControlDomainCall(string name, JObject arguments, params string[] domains)
+        {
+            McpTool tool;
+            if (!OniToolRegistry.TryGetTool(name, out tool)
+                || !string.Equals(tool.Name, ToolName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            string domain = (arguments?["domain"]?.ToString() ?? "diagnostics").Trim().ToLowerInvariant();
+            foreach (var candidate in domains)
+            {
+                if (string.Equals(domain, candidate, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
         }
 
         public static McpTool DiagnosticsControl()

--- a/mods/oni_mcp/Tools/Legacy/Impl/Server/ToolBatchTools.cs
+++ b/mods/oni_mcp/Tools/Legacy/Impl/Server/ToolBatchTools.cs
@@ -213,9 +213,6 @@ namespace OniMcp.Tools
 
             string callId = call["id"]?.ToString() ?? call["key"]?.ToString();
 
-            if (string.Equals(name, ToolName, StringComparison.OrdinalIgnoreCase))
-                return ErrorResult(index, name, call, $"{ToolName} cannot call itself");
-
             var argumentsToken = call["arguments"] ?? call["args"] ?? call["a"];
             JObject arguments;
             if (argumentsToken == null || argumentsToken.Type == JTokenType.Null)
@@ -226,6 +223,9 @@ namespace OniMcp.Tools
                 return ErrorResult(index, name, call, "arguments must be an object");
 
             MergeDefaults(arguments, defaults);
+
+            if (IsBatchCall(name, arguments))
+                return ErrorResult(index, name, call, $"{ToolName} cannot call itself");
 
             McpTool tool;
             if (!OniToolRegistry.TryGetTool(name, out tool))
@@ -290,9 +290,6 @@ namespace OniMcp.Tools
             if (preflight.ContainsKey("isError") && (bool)preflight["isError"])
                 return preflight;
 
-            if (string.Equals(name, ToolName, StringComparison.OrdinalIgnoreCase))
-                return ErrorResult(index, name, call, $"{ToolName} cannot call itself");
-
             var argumentsToken = call["arguments"] ?? call["args"] ?? call["a"];
             JObject arguments;
             if (argumentsToken == null || argumentsToken.Type == JTokenType.Null)
@@ -309,6 +306,9 @@ namespace OniMcp.Tools
             }
 
             MergeDefaults(arguments, defaults);
+
+            if (IsBatchCall(name, arguments))
+                return ErrorResult(index, name, call, $"{ToolName} cannot call itself");
 
             McpTool tool;
             if (OniToolRegistry.TryGetTool(name, out tool)
@@ -343,6 +343,18 @@ namespace OniMcp.Tools
                 result["text"] = text;
             }
             return result;
+        }
+
+        private static bool IsBatchCall(string name, JObject arguments)
+        {
+            McpTool tool;
+            if (OniToolRegistry.TryGetTool(name, out tool)
+                && string.Equals(tool.Name, ToolName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return ServerTools.IsServerControlDomainCall(name, arguments, "batch", "call_many", "many");
         }
 
         private static void MergeDefaults(JObject target, JObject defaults)


### PR DESCRIPTION
### Motivation
- The `server_control` aggregate routes `domain=batch` and `domain=program` to existing batch/program executors but the legacy self-call guards only checked exact legacy tool names, allowing aliased `server_control` calls to recurse and cause DoS by exhausting stack/CPU.

### Description
- Introduce a canonical `server_control` constant `ToolName` and a shared helper `IsServerControlDomainCall` in `mods/oni_mcp/Tools/Legacy/Impl/Server/ServerTools.cs` to detect when a tool call is actually the aggregate routed to a sensitive domain.
- Update batch handling in `mods/oni_mcp/Tools/Legacy/Impl/Server/ToolBatchTools.cs` to use a new `IsBatchCall` helper that rejects recursive batch calls whether they are `tools_call_many` or `server_control` with `domain=batch`/`call_many`/`many` in both preflight and execution paths.
- Update agent program handling in `mods/oni_mcp/Tools/Legacy/Impl/Server/AgentProgramTools.cs` to use a new `IsProgramCall` helper that rejects recursive program calls whether they are `agent_program_execute` or `server_control` with `domain=program`/`agent_program`/`flow`/`script` during validation and execution.

### Testing
- Attempted to build with `dotnet build mods/oni_mcp/OniMcp.csproj`, but the container lacks the `dotnet` SDK so the build could not be run.
- Verified repository state and applied changes were committed and the modified files (`ServerTools.cs`, `ToolBatchTools.cs`, `AgentProgramTools.cs`) contain the new guards via automated diff checks which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45a219dbd48320b2fd79730d794511)

## Summary by Sourcery

防止通过 `server_control` 聚合工具路由的递归调用触发批处理和代理程序执行器，从而避免自我调用和潜在的拒绝服务（DoS）。

Bug 修复：
- 防止在直接调用或通过路由到批处理工具的 `server_control` 域调用时发生递归批处理执行。
- 防止在直接调用或通过路由到 program/flow/script 工具的 `server_control` 域调用时发生递归代理程序执行。

增强功能：
- 引入规范化的 `server_control` ToolName 和共享辅助方法，用于检测由批处理和代理程序防护逻辑使用的 `server_control` 域调用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard batch and agent program executors against recursive calls routed through the server_control aggregate tool to prevent self-invocation and potential DoS.

Bug Fixes:
- Prevent recursive batch execution when invoked directly or via server_control domains that route to batch tooling.
- Prevent recursive agent program execution when invoked directly or via server_control domains that route to program/flow/script tooling.

Enhancements:
- Introduce a canonical server_control ToolName and shared helper to detect server_control domain calls used by batch and agent program guards.

</details>