### PR TITLE
Fix utility auto-connect path expansion limit

### DIFF
--- a/mods/oni_mcp/Tools/Legacy/Impl/Build/BuildPlanningTools.cs
+++ b/mods/oni_mcp/Tools/Legacy/Impl/Build/BuildPlanningTools.cs
@@ -340,11 +340,10 @@ namespace OniMcp.Tools
                         return CallToolResult.Error("utility_auto_connect only supports linear utility prefabs such as Wire, LiquidConduit, GasConduit, SolidConduit and LogicWire");
 
                     string error;
-                    var path = ResolveUtilityPath(args, out error);
+                    int maxCells = Math.Max(1, Math.Min(ToolUtil.GetInt(args, "maxCells") ?? 200, 500));
+                    var path = ResolveUtilityPath(args, maxCells, out error);
                     if (error != null)
                         return CallToolResult.Error(error);
-
-                    int maxCells = Math.Max(1, Math.Min(ToolUtil.GetInt(args, "maxCells") ?? 200, 500));
                     if (path.Count > maxCells)
                         return CallToolResult.Error($"Path too large: {path.Count} cells, maxCells={maxCells}");
 
@@ -965,7 +964,7 @@ namespace OniMcp.Tools
             }
         }
 
-        private static List<CellCoord> ResolveUtilityPath(JObject args, out string error)
+        private static List<CellCoord> ResolveUtilityPath(JObject args, int maxCells, out string error)
         {
             error = null;
             var points = ParsePathPoints(args["points"]);
@@ -995,7 +994,10 @@ namespace OniMcp.Tools
 
             var path = new List<CellCoord>();
             for (int i = 0; i < points.Count - 1; i++)
-                AddManhattanSegment(path, points[i], points[i + 1]);
+            {
+                if (!AddManhattanSegment(path, points[i], points[i + 1], maxCells, out error))
+                    return path;
+            }
             return path;
         }
 
@@ -1346,21 +1348,37 @@ namespace OniMcp.Tools
             return result;
         }
 
-        private static void AddManhattanSegment(List<CellCoord> path, CellCoord from, CellCoord to)
+        private static bool AddManhattanSegment(List<CellCoord> path, CellCoord from, CellCoord to, int maxCells, out string error)
         {
+            error = null;
+
+            long dx = Math.Abs((long)to.x - from.x);
+            long dy = Math.Abs((long)to.y - from.y);
+            long cellsToAdd = dx + dy + 1;
+            if (path.Count > 0 && path[path.Count - 1].x == from.x && path[path.Count - 1].y == from.y)
+                cellsToAdd--;
+
+            long resultingCount = (long)path.Count + cellsToAdd;
+            if (resultingCount > maxCells)
+            {
+                error = $"Path too large: {resultingCount} cells, maxCells={maxCells}";
+                return false;
+            }
+
             int x = from.x;
             int y = from.y;
             AddPathPoint(path, x, y);
             while (x != to.x)
             {
-                x += Math.Sign(to.x - x);
+                x += to.x > x ? 1 : -1;
                 AddPathPoint(path, x, y);
             }
             while (y != to.y)
             {
-                y += Math.Sign(to.y - y);
+                y += to.y > y ? 1 : -1;
                 AddPathPoint(path, x, y);
             }
+            return true;
         }
 
         private static void AddPathPoint(List<CellCoord> path, int x, int y)
@@ -1739,10 +1757,10 @@ namespace OniMcp.Tools
                 };
             }
 
-            var path = new List<CellCoord>();
-            AddManhattanSegment(path, CellCoordFromCell(sourceCell), CellCoordFromCell(inputCell));
             int maxCells = Math.Max(1, Math.Min(ToolUtil.GetInt(args, "maxCells") ?? 200, 500));
-            if (path.Count > maxCells)
+            var path = new List<CellCoord>();
+            string pathError;
+            if (!AddManhattanSegment(path, CellCoordFromCell(sourceCell), CellCoordFromCell(inputCell), maxCells, out pathError))
             {
                 return new Dictionary<string, object>
                 {
@@ -1750,6 +1768,7 @@ namespace OniMcp.Tools
                     ["status"] = "path_too_large",
                     ["input"] = CellCoordDictionary(inputCell),
                     ["source"] = CellCoordDictionary(sourceCell),
+                    ["error"] = pathError,
                     ["pathCells"] = path.Count,
                     ["maxCells"] = maxCells,
                     ["planned"] = 0,


### PR DESCRIPTION
### Motivation
- Prevent an algorithmic DoS where `utility_auto_connect` could materialize arbitrarily large Manhattan paths before enforcing `maxCells`, allowing a remote client to consume excessive CPU/memory.
- Enforce the intended `maxCells` safety bound during path construction so oversized requests are rejected early.

### Description
- Clamp and read `maxCells` early and pass it into `ResolveUtilityPath` so the resolver can enforce limits while building the path instead of after full materialization.
- Change `ResolveUtilityPath` signature to `ResolveUtilityPath(JObject args, int maxCells, out string error)` and stop path construction when a segment would exceed `maxCells`.
- Replace unbounded `AddManhattanSegment` with a bounded variant `AddManhattanSegment(List<CellCoord> path, CellCoord from, CellCoord to, int maxCells, out string error)` that precomputes `cellsToAdd` using `long` arithmetic and rejects segments whose cumulative length would exceed `maxCells` before per-cell expansion.
- Apply the same bounded segment logic to the automatic power wire planning path so all auto-connect flows fail fast on oversized routes.

### Testing
- Ran `git diff --check` with no warnings reported. (success)
- Ran `cargo test` in the repository which completed successfully (no failing tests). (success)
- Attempted `dotnet build mods/oni_mcp/OniMcp.csproj` but `dotnet` is not available in the environment so the C# build could not be executed; the change is limited and localized to path construction logic in `BuildPlanningTools.cs`. (skipped)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45a4e1da9083209eee95ceaee4ae67)

## Summary by Sourcery

在构建 utility 自动连接路径时强制执行 `maxCells` 安全限制，避免过大的曼哈顿路径导致资源使用过多。

Bug Fixes:
- 在路径解析和线段扩展过程中强制执行 `maxCells`，防止 `utility_auto_connect` 通过实例化任意大的路径。
- 对自动电源线规划应用有界的曼哈顿路径构建，使超大路径能够快速以错误形式失败。

Enhancements:
- 优化 `ResolveUtilityPath` 和 `AddManhattanSegment` 接口以接受 `maxCells` 并返回错误，从而在路径过大时可及早终止。
- 在电源自动连接的响应中传播详细的路径大小错误信息，包括实际报告的路径大小以及配置的 `maxCells`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce the maxCells safety limit during utility auto-connect path construction to avoid overly large Manhattan paths causing excessive resource usage.

Bug Fixes:
- Prevent utility_auto_connect from materializing arbitrarily large paths by enforcing maxCells during path resolution and segment expansion.
- Apply bounded Manhattan path construction to automatic power wire planning so oversized routes fail fast with an error.

Enhancements:
- Refine ResolveUtilityPath and AddManhattanSegment interfaces to accept maxCells and return errors, enabling early termination on oversized paths.
- Propagate detailed path size error information in power auto-connect responses, including the reported path size and configured maxCells.

</details>