### PR TITLE
Enforce maxCells during utility path expansion to prevent unbounded enumeration

### DIFF
--- a/mods/oni_mcp/Tools/Legacy/Impl/Build/BuildPlanningTools.cs
+++ b/mods/oni_mcp/Tools/Legacy/Impl/Build/BuildPlanningTools.cs
@@ -1368,32 +1368,33 @@ namespace OniMcp.Tools
 
             int x = from.x;
             int y = from.y;
+            if (!TryAddPathPoint(path, x, y, maxCells, out error))
+                return false;
+            while (x != to.x)
+            {
+                x += Math.Sign(to.x - x);
+                if (!TryAddPathPoint(path, x, y, maxCells, out error))
+                    return false;
+            }
+            while (y != to.y)
+            {
+                y += Math.Sign(to.y - y);
+                if (!TryAddPathPoint(path, x, y, maxCells, out error))
+                    return false;
+            }
+            return true;
+        }
+
+        private static bool TryAddPathPoint(List<CellCoord> path, int x, int y, int maxCells, out string error)
+        {
             AddPathPoint(path, x, y);
             if (path.Count > maxCells)
             {
                 error = $"Path too large: {path.Count} cells, maxCells={maxCells}";
                 return false;
             }
-            while (x != to.x)
-            {
-                x += to.x > x ? 1 : -1;
-                AddPathPoint(path, x, y);
-                if (path.Count > maxCells)
-                {
-                    error = $"Path too large: {path.Count} cells, maxCells={maxCells}";
-                    return false;
-                }
-            }
-            while (y != to.y)
-            {
-                y += to.y > y ? 1 : -1;
-                AddPathPoint(path, x, y);
-                if (path.Count > maxCells)
-                {
-                    error = $"Path too large: {path.Count} cells, maxCells={maxCells}";
-                    return false;
-                }
-            }
+
+            error = null;
             return true;
         }
 

--- a/mods/oni_mcp/Tools/Legacy/Impl/Build/BuildPlanningTools.cs
+++ b/mods/oni_mcp/Tools/Legacy/Impl/Build/BuildPlanningTools.cs
@@ -339,12 +339,12 @@ namespace OniMcp.Tools
                     if (!IsLinearUtilityPrefab(def.PrefabID))
                         return CallToolResult.Error("utility_auto_connect only supports linear utility prefabs such as Wire, LiquidConduit, GasConduit, SolidConduit and LogicWire");
 
+                    int maxCells = Math.Max(1, Math.Min(ToolUtil.GetInt(args, "maxCells") ?? 200, 500));
                     string error;
-                    var path = ResolveUtilityPath(args, out error);
+                    var path = ResolveUtilityPath(args, maxCells, out error);
                     if (error != null)
                         return CallToolResult.Error(error);
 
-                    int maxCells = Math.Max(1, Math.Min(ToolUtil.GetInt(args, "maxCells") ?? 200, 500));
                     if (path.Count > maxCells)
                         return CallToolResult.Error($"Path too large: {path.Count} cells, maxCells={maxCells}");
 
@@ -965,7 +965,7 @@ namespace OniMcp.Tools
             }
         }
 
-        private static List<CellCoord> ResolveUtilityPath(JObject args, out string error)
+        private static List<CellCoord> ResolveUtilityPath(JObject args, int maxCells, out string error)
         {
             error = null;
             var points = ParsePathPoints(args["points"]);
@@ -995,7 +995,10 @@ namespace OniMcp.Tools
 
             var path = new List<CellCoord>();
             for (int i = 0; i < points.Count - 1; i++)
-                AddManhattanSegment(path, points[i], points[i + 1]);
+            {
+                if (!TryAddManhattanSegment(path, points[i], points[i + 1], maxCells, out error))
+                    return path;
+            }
             return path;
         }
 
@@ -1346,21 +1349,38 @@ namespace OniMcp.Tools
             return result;
         }
 
-        private static void AddManhattanSegment(List<CellCoord> path, CellCoord from, CellCoord to)
+        private static bool TryAddManhattanSegment(List<CellCoord> path, CellCoord from, CellCoord to, int maxCells, out string error)
         {
+            error = null;
             int x = from.x;
             int y = from.y;
             AddPathPoint(path, x, y);
+            if (path.Count > maxCells)
+            {
+                error = $"Path too large: {path.Count} cells, maxCells={maxCells}";
+                return false;
+            }
             while (x != to.x)
             {
-                x += Math.Sign(to.x - x);
+                x += to.x > x ? 1 : -1;
                 AddPathPoint(path, x, y);
+                if (path.Count > maxCells)
+                {
+                    error = $"Path too large: {path.Count} cells, maxCells={maxCells}";
+                    return false;
+                }
             }
             while (y != to.y)
             {
-                y += Math.Sign(to.y - y);
+                y += to.y > y ? 1 : -1;
                 AddPathPoint(path, x, y);
+                if (path.Count > maxCells)
+                {
+                    error = $"Path too large: {path.Count} cells, maxCells={maxCells}";
+                    return false;
+                }
             }
+            return true;
         }
 
         private static void AddPathPoint(List<CellCoord> path, int x, int y)
@@ -1739,9 +1759,24 @@ namespace OniMcp.Tools
                 };
             }
 
-            var path = new List<CellCoord>();
-            AddManhattanSegment(path, CellCoordFromCell(sourceCell), CellCoordFromCell(inputCell));
             int maxCells = Math.Max(1, Math.Min(ToolUtil.GetInt(args, "maxCells") ?? 200, 500));
+            string pathError;
+            var path = new List<CellCoord>();
+            if (!TryAddManhattanSegment(path, CellCoordFromCell(sourceCell), CellCoordFromCell(inputCell), maxCells, out pathError))
+            {
+                return new Dictionary<string, object>
+                {
+                    ["enabled"] = true,
+                    ["status"] = "path_too_large",
+                    ["input"] = CellCoordDictionary(inputCell),
+                    ["source"] = CellCoordDictionary(sourceCell),
+                    ["pathCells"] = path.Count,
+                    ["maxCells"] = maxCells,
+                    ["planned"] = 0,
+                    ["failed"] = 0,
+                    ["error"] = pathError
+                };
+            }
             if (path.Count > maxCells)
             {
                 return new Dictionary<string, object>
@@ -1822,8 +1857,8 @@ namespace OniMcp.Tools
 
         private static IEnumerable<CellCoord> LineCells(int x1, int y1, int x2, int y2, HashSet<string> seen)
         {
-            int dx = Math.Sign(x2 - x1);
-            int dy = Math.Sign(y2 - y1);
+            int dx = x2 == x1 ? 0 : x2 > x1 ? 1 : -1;
+            int dy = y2 == y1 ? 0 : y2 > y1 ? 1 : -1;
             int x = x1;
             int y = y1;
             while (true)


### PR DESCRIPTION
### Motivation
- Prevent unbounded path/route expansion in build planning that can enumerate extremely large coordinate ranges before the `maxCells` guard, causing CPU/memory exhaustion and an MCP denial-of-service.

### Description
- Move the `maxCells` computation before resolving utility paths and pass it into `ResolveUtilityPath` by changing the signature to `ResolveUtilityPath(JObject args, int maxCells, out string error)`. 
- Add `TryAddManhattanSegment` which appends Manhattan-segment points while checking `maxCells` at each step and returns an error when the cap is exceeded, replacing the previous unbounded `AddManhattanSegment` behavior. 
- Use the bounded path construction in auto-connect/`PlanAtPointer` flows so oversized paths return a `path_too_large` result immediately instead of materializing all points. 
- Replace `Math.Sign(x2 - x1)`/`Math.Sign(y2 - y1)` with explicit comparisons for `dx`/`dy` calculations in `LineCells` to avoid overflow/undefined behavior for extreme endpoint values.

### Testing
- Ran `git diff --check` which succeeded. 
- Attempted `dotnet build mods/oni_mcp/OniMcp.csproj -c Debug` but the build was blocked because `dotnet` is not installed in the execution environment, so a full compile/test could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45b94af0ac8320b3ff5cedf82afa8f)

## Summary by Sourcery

通过在路径解析和自动连接流程中应用 `maxCells` 限制，强制对公用设施路径（utility path）的构建进行边界约束，从而防止无界路径枚举和潜在的资源耗尽。

Bug 修复：
- 在构建曼哈顿（Manhattan）线段时，用 `maxCells` 限制公用设施路径扩展，使过长路径能在早期被拒绝，而不是被完全实例化。
- 确保当计算得到的曼哈顿路径超过配置的 `maxCells` 限制时，电力自动连接功能会返回 `path_too_large` 状态。
- 通过用显式的端点比较替换基于 `Math.Sign` 的增量计算，避免在 `LineCells` 方向计算中可能出现的溢出或未定义行为。

增强：
- 将曼哈顿线段构建重构为一个支持 `maxCells` 的 `TryAddManhattanSegment` 辅助方法，并在通用公用设施路径解析和电力自动连接逻辑中复用该方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce bounded utility path construction by applying maxCells limits during path resolution and auto-connect flows to prevent unbounded path enumeration and potential resource exhaustion.

Bug Fixes:
- Guard utility path expansion with maxCells during Manhattan segment construction so excessively long paths are rejected early instead of being fully materialized.
- Ensure power auto-connect returns a path_too_large status when the computed Manhattan path exceeds the configured maxCells limit.
- Avoid potential overflow or undefined behavior in LineCells direction calculation by replacing Math.Sign-based deltas with explicit endpoint comparisons.

Enhancements:
- Refactor Manhattan segment construction into a maxCells-aware TryAddManhattanSegment helper reused by both generic utility path resolution and power auto-connect logic.

</details>