### PR TITLE
Secure MCP HTTP control plane

### DIFF
--- a/mods/oni_mcp/Config/OniMcpOptions.cs
+++ b/mods/oni_mcp/Config/OniMcpOptions.cs
@@ -23,10 +23,10 @@ namespace OniMcp.Config
         public int Port { get; set; } = 8788;
 
         [Option("Require token", "Require clients to send the configured bearer token.", "Authentication")]
-        public bool AuthEnabled { get; set; } = false;
+        public bool AuthEnabled { get; set; } = true;
 
         [Option("Token", "Bearer token required when token authentication is enabled.", "Authentication")]
-        public string AuthToken { get; set; } = "";
+        public string AuthToken { get; set; } = CreateAuthToken();
 
         [Option("Disable auto disinfect globally", "Keep ONI's global auto disinfect setting disabled when the mod applies this policy.", "Gameplay")]
         public bool GlobalAutoDisinfectDisabled { get; set; } = false;
@@ -192,11 +192,16 @@ namespace OniMcp.Config
             if (options.Port < 1024 || options.Port > 65535)
                 options.Port = 8788;
             options.AuthToken = (options.AuthToken ?? "").Trim();
-            if (string.IsNullOrEmpty(options.AuthToken))
-                options.AuthEnabled = false;
+            if (options.AuthEnabled && string.IsNullOrEmpty(options.AuthToken))
+                options.AuthToken = CreateAuthToken();
             options.ScreenshotRetentionMinutes = Clamp(options.ScreenshotRetentionMinutes, 1, 10080);
             options.ScreenshotMaxFiles = Clamp(options.ScreenshotMaxFiles, 1, 1000);
             return options;
+        }
+
+        private static string CreateAuthToken()
+        {
+            return Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N");
         }
 
         private static string NormalizeHost(string host)

--- a/mods/oni_mcp/Server/McpHttpServer.cs
+++ b/mods/oni_mcp/Server/McpHttpServer.cs
@@ -161,8 +161,14 @@ namespace OniMcp.Server
 
             try
             {
-                if (!ApplyCors(request, response))
+                string corsOrigin;
+                if (!TryValidateCors(request, out corsOrigin))
+                {
+                    SendJson(response, JsonRpcResponse.MakeError(null, McpErrorCode.InvalidRequest, "Forbidden CORS origin"), 403);
                     return;
+                }
+
+                ApplyCorsHeaders(response, corsOrigin);
 
                 response.Headers.Add("Access-Control-Allow-Methods", "GET, HEAD, POST, DELETE, OPTIONS");
                 response.Headers.Add("Access-Control-Allow-Headers", "Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Accept, Authorization, X-Oni-Mcp-Token");
@@ -338,35 +344,44 @@ namespace OniMcp.Server
             DispatchPostResponse(response, rpcRequest, sessionId);
         }
 
-        private bool ApplyCors(HttpListenerRequest request, HttpListenerResponse response)
+        private bool TryValidateCors(HttpListenerRequest request, out string origin)
         {
-            string origin = request.Headers["Origin"];
+            origin = request.Headers["Origin"];
             if (string.IsNullOrWhiteSpace(origin))
                 return true;
 
             Uri originUri;
-            if (!Uri.TryCreate(origin, UriKind.Absolute, out originUri) || !IsLoopbackHost(originUri.Host))
-            {
-                SendJson(response, JsonRpcResponse.MakeError(null, McpErrorCode.InvalidRequest, "Forbidden CORS origin"), 403);
+            if (!Uri.TryCreate(origin, UriKind.Absolute, out originUri) || !originUri.IsLoopback)
                 return false;
-            }
 
-            response.Headers["Access-Control-Allow-Origin"] = origin;
-            response.Headers["Vary"] = "Origin";
             return true;
         }
 
-        private static bool IsLoopbackHost(string host)
+        private static void ApplyCorsHeaders(HttpListenerResponse response, string origin)
         {
-            if (string.IsNullOrWhiteSpace(host))
-                return false;
+            if (string.IsNullOrWhiteSpace(origin))
+                return;
 
-            host = host.Trim().Trim('[', ']').ToLowerInvariant();
-            if (host == "localhost")
-                return true;
+            response.Headers["Access-Control-Allow-Origin"] = origin;
+            AppendVaryOrigin(response);
+        }
 
-            IPAddress address;
-            return IPAddress.TryParse(host, out address) && IPAddress.IsLoopback(address);
+        private static void AppendVaryOrigin(HttpListenerResponse response)
+        {
+            string existingVary = response.Headers["Vary"];
+            if (string.IsNullOrEmpty(existingVary))
+            {
+                response.Headers["Vary"] = "Origin";
+                return;
+            }
+
+            foreach (var value in existingVary.Split(','))
+            {
+                if (string.Equals(value.Trim(), "Origin", StringComparison.OrdinalIgnoreCase))
+                    return;
+            }
+
+            response.Headers["Vary"] = existingVary + ", Origin";
         }
 
         private bool ValidateAuth(HttpListenerRequest request, HttpListenerResponse response)

--- a/mods/oni_mcp/Server/McpHttpServer.cs
+++ b/mods/oni_mcp/Server/McpHttpServer.cs
@@ -161,8 +161,9 @@ namespace OniMcp.Server
 
             try
             {
-                // CORS
-                response.Headers.Add("Access-Control-Allow-Origin", "*");
+                if (!ApplyCors(request, response))
+                    return;
+
                 response.Headers.Add("Access-Control-Allow-Methods", "GET, HEAD, POST, DELETE, OPTIONS");
                 response.Headers.Add("Access-Control-Allow-Headers", "Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Accept, Authorization, X-Oni-Mcp-Token");
                 response.Headers.Add("Access-Control-Expose-Headers", "Mcp-Session-Id, Mcp-Protocol-Version");
@@ -335,6 +336,37 @@ namespace OniMcp.Server
             }
 
             DispatchPostResponse(response, rpcRequest, sessionId);
+        }
+
+        private bool ApplyCors(HttpListenerRequest request, HttpListenerResponse response)
+        {
+            string origin = request.Headers["Origin"];
+            if (string.IsNullOrWhiteSpace(origin))
+                return true;
+
+            Uri originUri;
+            if (!Uri.TryCreate(origin, UriKind.Absolute, out originUri) || !IsLoopbackHost(originUri.Host))
+            {
+                SendJson(response, JsonRpcResponse.MakeError(null, McpErrorCode.InvalidRequest, "Forbidden CORS origin"), 403);
+                return false;
+            }
+
+            response.Headers["Access-Control-Allow-Origin"] = origin;
+            response.Headers["Vary"] = "Origin";
+            return true;
+        }
+
+        private static bool IsLoopbackHost(string host)
+        {
+            if (string.IsNullOrWhiteSpace(host))
+                return false;
+
+            host = host.Trim().Trim('[', ']').ToLowerInvariant();
+            if (host == "localhost")
+                return true;
+
+            IPAddress address;
+            return IPAddress.TryParse(host, out address) && IPAddress.IsLoopback(address);
         }
 
         private bool ValidateAuth(HttpListenerRequest request, HttpListenerResponse response)


### PR DESCRIPTION
### Motivation
- The MCP HTTP control plane previously allowed any web origin to initialize sessions and call high-risk tools without proper authentication, enabling browser-driven attacks via permissive CORS and unauthenticated sessions.
- The change aims to eliminate easy cross-origin access and ensure the server requires a bearer token by default to prevent unauthorized manipulation of game/save lifecycle and other dangerous tools.

### Description
- Enable token authentication by default via `AuthEnabled = true` and generate a per-install bearer token when the configured token is empty by adding `CreateAuthToken()` in `OniMcpOptions`.
- Preserve automatic token creation during config sanitization so an enabled-but-empty token will be replaced with a generated token instead of silently disabling authentication.
- Replace the previous wildcard CORS header with an `ApplyCors` gate that allows requests from loopback browser origins only and returns `403` for non-loopback origins while still permitting non-browser clients that omit the `Origin` header.
- Add `IsLoopbackHost` helper to validate origins are loopback and set `Access-Control-Allow-Origin` to the request origin with `Vary: Origin` to avoid exposing the session header to remote web pages.

### Testing
- Verified repository changes with `git diff --check` (no diff-check issues reported) and inspected the modified files with `rg` patterns to confirm the wildcard CORS and default-unauth settings were removed or updated; these checks succeeded.
- Confirmed `OniMcpOptions` now defaults to enabled auth and creates tokens when none are present by inspecting the updated `Sanitize` and `CreateAuthToken` implementation; static inspection succeeded.
- Attempted to build with `dotnet build mods/oni_mcp/OniMcp.csproj -c Debug` but the build could not be run in this environment because `dotnet` is not installed (platform limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45c4730d648320b089b7acd836db15)

## Summary by Sourcery

通过强制身份验证访问，并将来自浏览器的 CORS 限制为受信任的回环主机，保护 MCP HTTP 控制平面。

新功能：
- 当未配置身份验证令牌时，默认生成每次安装唯一的 bearer token。

改进：
- 在 MCP HTTP 服务器选项中默认启用基于令牌的身份验证。
- 将 CORS 访问限制为来自回环地址的浏览器来源，同时允许没有 Origin 头的非浏览器客户端访问。
- 对来自非回环来源的请求返回明确的 403 错误，以防止未授权的跨域访问。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Secure the MCP HTTP control plane by enforcing authenticated access and restricting browser-origin CORS to trusted loopback hosts.

New Features:
- Generate a per-install bearer token by default when no authentication token is configured.

Enhancements:
- Enable token-based authentication by default in MCP HTTP server options.
- Restrict CORS access to loopback browser origins while allowing non-browser clients without an Origin header.
- Return explicit 403 errors for requests from non-loopback origins to prevent unauthorized cross-origin access.

</details>