### PR TITLE
Limit agent_program_execute execution budget and truncate child outputs

### DIFF
--- a/mods/oni_mcp/Tools/Legacy/Impl/Server/AgentProgramTools.cs
+++ b/mods/oni_mcp/Tools/Legacy/Impl/Server/AgentProgramTools.cs
@@ -12,6 +12,12 @@ namespace OniMcp.Tools
     public static class AgentProgramTools
     {
         private const string ToolName = "agent_program_execute";
+        private const int DefaultMaxSteps = 100;
+        private const int HardMaxSteps = 200;
+        private const int DefaultMaxLoopIterations = 10;
+        private const int HardMaxLoopIterations = 25;
+        private const int MaxChildToolCalls = 50;
+        private const int MaxStoredResultChars = 4000;
 
         public static McpTool ExecuteProgram()
         {
@@ -41,19 +47,19 @@ namespace OniMcp.Tools
                     ["maxSteps"] = new McpToolParameter
                     {
                         Type = "integer",
-                        Description = "最大执行语句数，防止死循环，默认 200，最大 2000",
+                        Description = "最大执行语句数，防止死循环，默认 100，最大 200",
                         Required = false
                     },
                     ["maxLoopIterations"] = new McpToolParameter
                     {
                         Type = "integer",
-                        Description = "单个 while/repeat 最大迭代次数，默认 100，最大 1000",
+                        Description = "单个 while/repeat 最大迭代次数，默认 10，最大 25",
                         Required = false
                     },
                     ["trace"] = new McpToolParameter
                     {
                         Type = "boolean",
-                        Description = "是否返回详细执行 trace，默认 true；关闭后只返回摘要和最终变量",
+                        Description = "是否返回详细执行 trace，默认 false；trace 中的子调用结果会被截断",
                         Required = false
                     }
                 },
@@ -65,9 +71,9 @@ namespace OniMcp.Tools
                         return CallToolResult.Error(error);
 
                     bool dryRun = ToolUtil.GetBool(args, "dryRun", false);
-                    int maxSteps = Math.Max(1, Math.Min(ToolUtil.GetInt(args, "maxSteps") ?? 200, 2000));
-                    int maxLoopIterations = Math.Max(1, Math.Min(ToolUtil.GetInt(args, "maxLoopIterations") ?? 100, 1000));
-                    bool includeTrace = ToolUtil.GetBool(args, "trace", true);
+                    int maxSteps = Math.Max(1, Math.Min(ToolUtil.GetInt(args, "maxSteps") ?? DefaultMaxSteps, HardMaxSteps));
+                    int maxLoopIterations = Math.Max(1, Math.Min(ToolUtil.GetInt(args, "maxLoopIterations") ?? DefaultMaxLoopIterations, HardMaxLoopIterations));
+                    bool includeTrace = ToolUtil.GetBool(args, "trace", false);
 
                     var runner = new AgentProgramRunner(dryRun, maxSteps, maxLoopIterations, includeTrace);
                     var payload = runner.Run(program);
@@ -124,6 +130,7 @@ namespace OniMcp.Tools
             private readonly HashSet<string> referencedTools = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             private JToken last = JValue.CreateNull();
             private int executedSteps;
+            private int childToolCalls;
             private bool returned;
             private JToken returnValue = JValue.CreateNull();
 
@@ -169,6 +176,8 @@ namespace OniMcp.Tools
                     ["dryRun"] = dryRun,
                     ["valid"] = valid,
                     ["executedSteps"] = dryRun ? 0 : executedSteps,
+                    ["childToolCalls"] = dryRun ? 0 : childToolCalls,
+                    ["maxChildToolCalls"] = MaxChildToolCalls,
                     ["maxSteps"] = maxSteps,
                     ["maxLoopIterations"] = maxLoopIterations,
                     ["referencedTools"] = referencedTools.OrderBy(name => name).ToList(),
@@ -269,6 +278,8 @@ namespace OniMcp.Tools
                 if (TryResolveCallShape(stmt, out toolName, out ignored, out ignoredSave))
                 {
                     referencedTools.Add(toolName);
+                    if (IsBlockedChildTool(toolName))
+                        throw new AgentProgramException(path + " cannot reference nested program or batch tool: " + toolName);
                     McpTool tool;
                     if (!OniToolRegistry.TryGetTool(toolName, out tool))
                         throw new AgentProgramException(path + " references unknown tool: " + toolName);
@@ -416,20 +427,18 @@ namespace OniMcp.Tools
             private void ExecuteCall(string toolName, JObject rawArgs, string saveAs, bool continueOnError, string path)
             {
                 referencedTools.Add(toolName);
-                if (string.Equals(toolName, ToolName, StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(toolName, "agent_script_run", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(toolName, "agent_flow_execute", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(toolName, "agent_program_run", StringComparison.OrdinalIgnoreCase))
-                {
-                    throw new AgentProgramException("agent program cannot call itself");
-                }
+                if (IsBlockedChildTool(toolName))
+                    throw new AgentProgramException("agent program cannot call nested program or batch tools: " + toolName);
+                if (childToolCalls >= MaxChildToolCalls)
+                    throw new AgentProgramException("maxChildToolCalls exceeded at " + path);
+                childToolCalls++;
 
                 JObject args = ResolveObject(rawArgs);
                 if (toolName == "world_cell_info" && (args["x"] == null || args["y"] == null))
                     FillCurrentPointerCell(args);
 
                 var result = OniToolRegistry.CallTool(toolName, args);
-                string text = ResultText(result);
+                string text = Truncate(ResultText(result), MaxStoredResultChars);
                 JToken json = TryParseJson(text);
                 var wrapped = new JObject
                 {
@@ -858,6 +867,22 @@ namespace OniMcp.Tools
                 if (result == null || result.Content == null || result.Content.Count == 0 || result.Content[0] == null)
                     return "";
                 return result.Content[0].Text ?? "";
+            }
+
+            private static bool IsBlockedChildTool(string toolName)
+            {
+                return string.Equals(toolName, ToolName, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(toolName, "agent_script_run", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(toolName, "agent_flow_execute", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(toolName, "agent_program_run", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(toolName, ToolBatchTools.ToolName, StringComparison.OrdinalIgnoreCase);
+            }
+
+            private static string Truncate(string text, int maxChars)
+            {
+                if (string.IsNullOrEmpty(text) || text.Length <= maxChars)
+                    return text ?? "";
+                return text.Substring(0, maxChars) + "...[truncated]";
             }
 
             private static JToken TryParseJson(string text)


### PR DESCRIPTION
### Motivation
- Mitigate a discovered availability/DoS vector where `agent_program_execute` could synchronously invoke many expensive MCP tools on the Unity main thread and return unbounded child results.
- Reduce default and hard limits and prevent amplification shapes (nested programs/batches) while preserving the program execution feature.

### Description
- Lowered defaults and hard caps for program execution by introducing `DefaultMaxSteps=100`, `HardMaxSteps=200`, `DefaultMaxLoopIterations=10`, and `HardMaxLoopIterations=25`, and changed the `trace` default to off in `mods/oni_mcp/Tools/Legacy/Impl/Server/AgentProgramTools.cs`.
- Added a per-execution child-call counter and hard budget (`MaxChildToolCalls = 50`) and surface `childToolCalls`/`maxChildToolCalls` in the returned payload to account for child tool usage.
- Blocked nested program/tool-batch invocation by detecting and rejecting calls to program aliases and `tools_call_many` during validation and at call time to prevent nested amplification.
- Truncated stored child tool output (`MaxStoredResultChars = 4000`) before parsing/storing it into `last`, saved variables, or trace, and added `IsBlockedChildTool` and `Truncate` helpers to implement these protections.

### Testing
- Ran `cargo test` in the repository which completed successfully (no failing tests).
- Attempted `dotnet build mods/oni_mcp/OniMcp.csproj -c Debug` but it was not executed due to `dotnet` not being available in the environment, so C# build was not validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45a727843483209e92f1514c5e1d7d)

## Summary by Sourcery

将 `agent_program_execute` 的程序执行限制在更严格的预算内，防止嵌套放大，并约束存储的子工具输出。

增强内容：
- 降低程序步骤数和循环迭代次数的默认与硬性上限，并将 `agent_program_execute` 的追踪（trace）默认改为禁用。
- 跟踪并暴露每次执行的子工具调用次数，并设置硬性上限，以约束下游工具的使用量。
- 阻止从 `agent_program_execute` 发起嵌套的程序调用和批量工具调用，以避免递归或批量放大路径。
- 在将子工具输出保存到 `last`、`variables` 或 `trace` 之前进行截断，以限制负载大小并控制工具结果的扩散范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit agent_program_execute program executions to stricter budgets and prevent nested amplification while constraining stored child tool outputs.

Enhancements:
- Reduce default and hard limits for program steps and loop iterations and change trace to be disabled by default for agent_program_execute.
- Track and expose a per-execution child tool call count with a hard cap to bound downstream tool usage.
- Block nested program and batch tool invocations from agent_program_execute to avoid recursive or batched amplification paths.
- Truncate stored child tool output before saving into last, variables, or trace to cap payload size and tool result fan-out.

</details>