### PR TITLE
fix(windows): Dev deploy path + Expand-Archive quoting

### DIFF
--- a/docs/WINDOWS_DEV.md
+++ b/docs/WINDOWS_DEV.md
@@ -1,0 +1,22 @@
+# Windows Dev notes (`onim dev`)
+
+## What broke on a real Windows install
+
+1. **Mod install path**: `onim` wrote under `AppData\LocalLow\Klei\Oxygen Not Included\mods\Dev`, but the game loaded mods from `Documents\Klei\OxygenNotIncluded\mods` (see Player.log `Loaded assembly ...\Documents\Klei\OxygenNotIncluded\mods\...`).
+2. **Expand-Archive spaces**: destination paths containing `Oxygen Not Included` were split into multiple PowerShell arguments when unquoted.
+3. **Source tarball**: `tar -czf 'D:\...'` fails with Windows `tar`; the mod zip itself was fine.
+
+## Fixes in this tree
+
+- Prefer `Documents\Klei\OxygenNotIncluded` when its `mods` folder exists; fall back to LocalLow.
+- Quote `Expand-Archive -LiteralPath` / `-DestinationPath` in `dev` and `install`.
+- Use double-quoted tar paths and do not fail the mod package if the optional source tarball errors.
+- Optional helper: `scripts/install_onim.bat` runs `vcvars64` then `cargo install --path .`.
+
+## Verify
+
+```bat
+onim dev -m oni_mcp
+:: restart Oxygen Not Included
+:: enable Dev mod; disable Steam Workshop copy if same staticID
+```

--- a/mods/oni_mcp/OniMcp.csproj
+++ b/mods/oni_mcp/OniMcp.csproj
@@ -161,8 +161,8 @@
     <!-- 打包成 zip (mod 发布包) -->
     <ZipDirectory SourceDirectory="$(DistModPath)" DestinationFile="$(ZipFile)" Overwrite="true" />
 
-    <!-- 打包源码成 tar.gz -->
-    <Exec Command="tar -czf '$(DistPath)$(AssemblyName)-src.tar.gz' -C '$(MSBuildProjectDirectory)' --exclude='bin' --exclude='obj' --exclude='dist' ." />
+    <!-- 打包源码成 tar.gz。Windows tar 不能用单引号包路径；源码包失败不阻断 mod zip。 -->
+    <Exec Command="tar -czf &quot;$(DistPath)$(AssemblyName)-src.tar.gz&quot; -C &quot;$(MSBuildProjectDirectory)&quot; --exclude=bin --exclude=obj --exclude=dist ." IgnoreExitCode="true" />
 
     <Message Text="Packaged mod -&gt; $(ZipFile)" Importance="high" />
     <Message Text="Packaged source -&gt; $(DistPath)$(AssemblyName)-src.tar.gz" Importance="high" />

--- a/scripts/install_onim.bat
+++ b/scripts/install_onim.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+REM Build/install onim CLI with a full MSVC environment (Git Bash's link.exe is not MSVC).
+call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat" || exit /b 1
+where link
+cargo install --path "%~dp0.." --force
+exit /b %ERRORLEVEL%

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,8 +302,19 @@ fn game_user_data_dir() -> Result<PathBuf> {
 
     #[cfg(target_os = "windows")]
     {
-        let local_low = env::var_os("USERPROFILE").context("无法获取 USERPROFILE")?;
-        Ok(PathBuf::from(local_low).join("AppData/LocalLow/Klei/Oxygen Not Included"))
+        // ONI loads Steam/Dev/Local mods from Documents\Klei\OxygenNotIncluded\mods.
+        // LocalLow\...\Oxygen Not Included holds logs/config for some installs, not the
+        // mod folders used by this Windows layout (see Player.log Loaded assembly path).
+        let profile = env::var_os("USERPROFILE").context("无法获取 USERPROFILE")?;
+        let documents = PathBuf::from(&profile).join("Documents/Klei/OxygenNotIncluded");
+        let local_low = PathBuf::from(&profile).join("AppData/LocalLow/Klei/Oxygen Not Included");
+        if documents.join("mods").exists() {
+            Ok(documents)
+        } else if local_low.join("mods").exists() {
+            Ok(local_low)
+        } else {
+            Ok(documents)
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -203,16 +203,16 @@ fn new_dev_mod_entry(selected: &SelectedMod, static_id: &str) -> Value {
 fn unzip(zip: &PathBuf, dest: &PathBuf) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
+        // Quote paths: unquoted Expand-Archive splits on spaces in
+        // "Oxygen Not Included" and fails with ParameterBindingException.
+        let zip_s = zip.to_string_lossy().replace('\'', "''");
+        let dest_s = dest.to_string_lossy().replace('\'', "''");
+        let ps = format!(
+            "Expand-Archive -LiteralPath '{}' -DestinationPath '{}' -Force",
+            zip_s, dest_s
+        );
         let status = Command::new("powershell")
-            .args([
-                "-Command",
-                "Expand-Archive",
-                "-Path",
-                &zip.to_string_lossy(),
-                "-DestinationPath",
-                &dest.to_string_lossy(),
-                "-Force",
-            ])
+            .args(["-NoProfile", "-Command", &ps])
             .status()
             .context("解压失败（PowerShell Expand-Archive）")?;
         if !status.success() {

--- a/src/install.rs
+++ b/src/install.rs
@@ -45,16 +45,16 @@ pub fn run(cfg: &Config, selected: &SelectedMod) -> Result<()> {
 fn unzip(zip: &PathBuf, dest: &PathBuf) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
+        // Quote paths: unquoted Expand-Archive splits on spaces in
+        // "Oxygen Not Included" and fails with ParameterBindingException.
+        let zip_s = zip.to_string_lossy().replace('\'', "''");
+        let dest_s = dest.to_string_lossy().replace('\'', "''");
+        let ps = format!(
+            "Expand-Archive -LiteralPath '{}' -DestinationPath '{}' -Force",
+            zip_s, dest_s
+        );
         let status = Command::new("powershell")
-            .args([
-                "-Command",
-                "Expand-Archive",
-                "-Path",
-                &zip.to_string_lossy(),
-                "-DestinationPath",
-                &dest.to_string_lossy(),
-                "-Force",
-            ])
+            .args(["-NoProfile", "-Command", &ps])
             .status()
             .context("解压失败（PowerShell Expand-Archive）")?;
         if !status.success() {


### PR DESCRIPTION
## Summary
- Prefer `Documents\Klei\OxygenNotIncluded` for Windows mod install when that `mods` tree exists (game loads Dev/Steam from there; LocalLow is mostly logs/config on this layout).
- Quote PowerShell `Expand-Archive -LiteralPath/-DestinationPath` so paths with spaces (`Oxygen Not Included`) no longer break `onim dev` / `onim install` after a successful build.
- Fix Windows `tar` quoting for the optional source tarball and do not fail the mod zip when that step errors.
- Add `scripts/install_onim.bat` (vcvars64 + `cargo install`) and `docs/WINDOWS_DEV.md`.

## Context
Hit while following the play → edit → `onim dev` → restart loop on Windows. Build succeeded but deploy failed or installed to a path the game did not load.

## Test plan
- [x] `cargo install --path .` (with MSVC vcvars) builds `onim`
- [x] `dotnet build` / `onim dev -m oni_mcp` produces `Documents\Klei\OxygenNotIncluded\mods\Dev\oni_mcp\` (OniMcp 0.2.1)
- [ ] Fresh Windows machine: `onim setup` + `onim dev -m oni_mcp`, restart ONI, confirm Player.log loads `...\mods\Dev\oni_mcp\OniMcp.dll`
- [ ] Disable Steam Workshop copy of the same staticID when testing Dev

## Summary by Sourcery

改进 ONI 模组在 Windows 平台上的开发和安装支持，重点确保正确的模组部署路径和更健壮的压缩包处理。

New Features:
- 添加一个 Windows 辅助脚本，在 MSVC 环境下安装 `onim` CLI。
- 添加 Windows 特定的开发说明文档，记录模组路径和故障排查步骤。

Bug Fixes:
- 修复 Windows 上的模组部署逻辑：当 Documents 路径下的 `Klei/OxygenNotIncluded` 树中存在 `mods` 目录时优先使用该路径，并在不存在时回退到 LocalLow。
- 修复 PowerShell 中 `Expand-Archive` 的使用方式，通过为路径添加引号，避免带空格的 Windows 安装路径导致开发与安装过程出错。
- 调整 Windows 下 `tar` 的调用方式，使可选的源码 tar 包创建过程不再导致模组打包失败。

Enhancements:
- 强化 Windows 下 ONI 用户数据目录路径的检测逻辑，通过在选择目标路径前检查 `mods` 文件夹是否存在。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Windows development and installation support for ONI mods, focusing on correct mod deployment paths and robust archive handling.

New Features:
- Add a Windows helper script to install the onim CLI with an MSVC environment.
- Add Windows-specific development notes documenting mod paths and troubleshooting steps.

Bug Fixes:
- Fix Windows mod deployment to prefer the Documents-based Klei/OxygenNotIncluded tree when its mods directory exists, with fallback to LocalLow.
- Fix PowerShell Expand-Archive usage by quoting paths so Windows installs with spaces no longer break dev and install operations.
- Adjust Windows tar invocation so optional source tarball creation no longer causes mod packaging to fail.

Enhancements:
- Harden Windows path detection logic for ONI user data directories by checking for existing mods folders before selecting a target.

</details>