### PR TITLE
fix(windows): Dev deploy path + Expand-Archive quoting

### DIFF
--- a/docs/WINDOWS_DEV.md
+++ b/docs/WINDOWS_DEV.md
@@ -8,10 +8,10 @@
 
 ## Fixes in this tree
 
-- Prefer `Documents\Klei\OxygenNotIncluded` when its `mods` folder exists; fall back to LocalLow.
-- Quote `Expand-Archive -LiteralPath` / `-DestinationPath` in `dev` and `install`.
-- Use double-quoted tar paths and do not fail the mod package if the optional source tarball errors.
-- Optional helper: `scripts/install_onim.bat` runs `vcvars64` then `cargo install --path .`.
+- Resolve the real Windows Documents Known Folder through `[Environment]::GetFolderPath([Environment+SpecialFolder]::MyDocuments)`, then install under `Klei\OxygenNotIncluded`; there is no `USERPROFILE\Documents` or LocalLow fallback.
+- Use the shared archive helper for `dev` and `install`. On Windows it invokes PowerShell with `-NoProfile -NonInteractive` and safely single-quotes `Expand-Archive -LiteralPath` / `-DestinationPath`; other platforms pass paths directly to `unzip` without a shell.
+- Use double-quoted tar paths and fail the build if the source tarball cannot be created.
+- Optional helper: `scripts/install_onim.bat` uses `vswhere` to find the latest Visual Studio instance containing `Microsoft.VisualStudio.Component.VC.Tools.x86.x64`, runs `vcvars64`, then installs with Cargo. Set `ONIM_VCVARS64` to override the discovered `vcvars64.bat` path.
 
 ## Verify
 

--- a/docs/WINDOWS_DEV.md
+++ b/docs/WINDOWS_DEV.md
@@ -1,0 +1,22 @@
+# Windows Dev notes (`onim dev`)
+
+## What broke on a real Windows install
+
+1. **Mod install path**: `onim` wrote under `AppData\LocalLow\Klei\Oxygen Not Included\mods\Dev`, but the game loaded mods from `Documents\Klei\OxygenNotIncluded\mods` (see Player.log `Loaded assembly ...\Documents\Klei\OxygenNotIncluded\mods\...`).
+2. **Expand-Archive spaces**: destination paths containing `Oxygen Not Included` were split into multiple PowerShell arguments when unquoted.
+3. **Source tarball**: `tar -czf 'D:\...'` fails with Windows `tar`; the mod zip itself was fine.
+
+## Fixes in this tree
+
+- Prefer `Documents\Klei\OxygenNotIncluded` when its `mods` folder exists; fall back to LocalLow.
+- Quote `Expand-Archive -LiteralPath` / `-DestinationPath` in `dev` and `install`.
+- Use double-quoted tar paths and do not fail the mod package if the optional source tarball errors.
+- Optional helper: `scripts/install_onim.bat` runs `vcvars64` then `cargo install --path .`.
+
+## Verify
+
+```bat
+onim dev -m oni_mcp
+:: restart Oxygen Not Included
+:: enable Dev mod; disable Steam Workshop copy if same staticID
+```

--- a/mods/oni_mcp/OniMcp.csproj
+++ b/mods/oni_mcp/OniMcp.csproj
@@ -161,8 +161,8 @@
     <!-- 打包成 zip (mod 发布包) -->
     <ZipDirectory SourceDirectory="$(DistModPath)" DestinationFile="$(ZipFile)" Overwrite="true" />
 
-    <!-- 打包源码成 tar.gz。Windows tar 不能用单引号包路径；源码包失败不阻断 mod zip。 -->
-    <Exec Command="tar -czf &quot;$(DistPath)$(AssemblyName)-src.tar.gz&quot; -C &quot;$(MSBuildProjectDirectory)&quot; --exclude=bin --exclude=obj --exclude=dist ." IgnoreExitCode="true" />
+    <!-- 打包源码成 tar.gz。Windows tar 不能用单引号包路径；源码包失败会使构建失败。 -->
+    <Exec Command="tar -czf &quot;$(DistPath)$(AssemblyName)-src.tar.gz&quot; -C &quot;$(MSBuildProjectDirectory)&quot; --exclude=bin --exclude=obj --exclude=dist ." />
 
     <Message Text="Packaged mod -&gt; $(ZipFile)" Importance="high" />
     <Message Text="Packaged source -&gt; $(DistPath)$(AssemblyName)-src.tar.gz" Importance="high" />

--- a/mods/oni_mcp/OniMcp.csproj
+++ b/mods/oni_mcp/OniMcp.csproj
@@ -161,8 +161,8 @@
     <!-- 打包成 zip (mod 发布包) -->
     <ZipDirectory SourceDirectory="$(DistModPath)" DestinationFile="$(ZipFile)" Overwrite="true" />
 
-    <!-- 打包源码成 tar.gz -->
-    <Exec Command="tar -czf '$(DistPath)$(AssemblyName)-src.tar.gz' -C '$(MSBuildProjectDirectory)' --exclude='bin' --exclude='obj' --exclude='dist' ." />
+    <!-- 打包源码成 tar.gz。Windows tar 不能用单引号包路径；源码包失败不阻断 mod zip。 -->
+    <Exec Command="tar -czf &quot;$(DistPath)$(AssemblyName)-src.tar.gz&quot; -C &quot;$(MSBuildProjectDirectory)&quot; --exclude=bin --exclude=obj --exclude=dist ." IgnoreExitCode="true" />
 
     <Message Text="Packaged mod -&gt; $(ZipFile)" Importance="high" />
     <Message Text="Packaged source -&gt; $(DistPath)$(AssemblyName)-src.tar.gz" Importance="high" />

--- a/scripts/install_onim.bat
+++ b/scripts/install_onim.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+REM Build/install onim CLI with a full MSVC environment (Git Bash's link.exe is not MSVC).
+call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat" || exit /b 1
+where link
+cargo install --path "%~dp0.." --force
+exit /b %ERRORLEVEL%

--- a/scripts/install_onim.bat
+++ b/scripts/install_onim.bat
@@ -1,7 +1,36 @@
 @echo off
 setlocal
 REM Build/install onim CLI with a full MSVC environment (Git Bash's link.exe is not MSVC).
-call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat" || exit /b 1
+
+if defined ONIM_VCVARS64 goto use_override
+
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" goto missing_vswhere
+
+for /f "usebackq delims=" %%I in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VSINSTALL=%%I"
+if not defined VSINSTALL goto missing_toolchain
+set "VCVARS64=%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat"
+goto validate_vcvars
+
+:use_override
+set "VCVARS64=%ONIM_VCVARS64%"
+
+:validate_vcvars
+if not exist "%VCVARS64%" goto missing_vcvars
+
+call "%VCVARS64%" || exit /b 1
 where link
 cargo install --path "%~dp0.." --force
 exit /b %ERRORLEVEL%
+
+:missing_vswhere
+echo ERROR: vswhere.exe was not found. Install Visual Studio Build Tools with the Desktop development with C++ workload, or set ONIM_VCVARS64.
+exit /b 1
+
+:missing_toolchain
+echo ERROR: No Visual Studio instance with Microsoft.VisualStudio.Component.VC.Tools.x86.x64 was found. Install the C++ build tools, or set ONIM_VCVARS64.
+exit /b 1
+
+:missing_vcvars
+echo ERROR: vcvars64.bat was not found at "%VCVARS64%".
+exit /b 1

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,0 +1,60 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+use std::process::Command;
+
+pub fn unzip(zip: &Path, dest: &Path) -> Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        let command = format!(
+            "Expand-Archive -LiteralPath '{}' -DestinationPath '{}' -Force -ErrorAction Stop",
+            escape_powershell_single_quoted(&zip.to_string_lossy()),
+            escape_powershell_single_quoted(&dest.to_string_lossy())
+        );
+        let status = Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                command.as_str(),
+            ])
+            .status()
+            .context("解压失败（PowerShell Expand-Archive）")?;
+        if !status.success() {
+            anyhow::bail!("解压失败（PowerShell Expand-Archive，退出状态：{status}）");
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let status = Command::new("unzip")
+            .arg("-o")
+            .arg(zip)
+            .arg("-d")
+            .arg(dest)
+            .status()
+            .context("解压失败（unzip），请确认已安装 unzip")?;
+        if !status.success() {
+            anyhow::bail!("解压失败（unzip，退出状态：{status}）");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn escape_powershell_single_quoted(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_powershell_single_quoted;
+
+    #[test]
+    fn powershell_single_quote_escape_should_double_embedded_quotes() {
+        assert_eq!(
+            escape_powershell_single_quoted(r"C:\Users\O'Neil\mod.zip"),
+            r"C:\Users\O''Neil\mod.zip"
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,8 +302,19 @@ fn game_user_data_dir() -> Result<PathBuf> {
 
     #[cfg(target_os = "windows")]
     {
-        let local_low = env::var_os("USERPROFILE").context("无法获取 USERPROFILE")?;
-        Ok(PathBuf::from(local_low).join("AppData/LocalLow/Klei/Oxygen Not Included"))
+        // ONI loads Steam/Dev/Local mods from Documents\Klei\OxygenNotIncluded\mods.
+        // LocalLow\...\Oxygen Not Included holds logs/config for some installs, not the
+        // mod folders used by this Windows layout (see Player.log Loaded assembly path).
+        let profile = env::var_os("USERPROFILE").context("无法获取 USERPROFILE")?;
+        let documents = PathBuf::from(&profile).join("Documents/Klei/OxygenNotIncluded");
+        let local_low = PathBuf::from(&profile).join("AppData/LocalLow/Klei/Oxygen Not Included");
+        if documents.join("mods").exists() {
+            Ok(documents)
+        } else if local_low.join("mods").exists() {
+            Ok(local_low)
+        } else {
+            Ok(documents)
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
+#[cfg(target_os = "windows")]
+use std::process::Command;
 
 const DEFAULT_CONFIG_NAME: &str = "onim.toml";
 const BUILD_PROPS: &str = "Directory.Build.props";
@@ -305,16 +307,31 @@ fn game_user_data_dir() -> Result<PathBuf> {
         // ONI loads Steam/Dev/Local mods from Documents\Klei\OxygenNotIncluded\mods.
         // LocalLow\...\Oxygen Not Included holds logs/config for some installs, not the
         // mod folders used by this Windows layout (see Player.log Loaded assembly path).
-        let profile = env::var_os("USERPROFILE").context("无法获取 USERPROFILE")?;
-        let documents = PathBuf::from(&profile).join("Documents/Klei/OxygenNotIncluded");
-        let local_low = PathBuf::from(&profile).join("AppData/LocalLow/Klei/Oxygen Not Included");
-        if documents.join("mods").exists() {
-            Ok(documents)
-        } else if local_low.join("mods").exists() {
-            Ok(local_low)
-        } else {
-            Ok(documents)
+        let output = Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); [Environment]::GetFolderPath([Environment+SpecialFolder]::MyDocuments)",
+            ])
+            .output()
+            .context("无法通过 Windows Known Folder API 获取 Documents 目录")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "通过 Windows Known Folder API 获取 Documents 目录失败（{}）：{}",
+                output.status,
+                stderr.trim()
+            );
         }
+
+        let documents = String::from_utf8(output.stdout)
+            .context("Windows Known Folder API 返回的 Documents 目录不是有效 UTF-8")?;
+        let documents = documents.trim();
+        if documents.is_empty() {
+            anyhow::bail!("Windows Known Folder API 返回了空的 Documents 目录");
+        }
+        Ok(PathBuf::from(documents).join("Klei/OxygenNotIncluded"))
     }
 
     #[cfg(target_os = "macos")]

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -203,16 +203,16 @@ fn new_dev_mod_entry(selected: &SelectedMod, static_id: &str) -> Value {
 fn unzip(zip: &PathBuf, dest: &PathBuf) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
+        // Quote paths: unquoted Expand-Archive splits on spaces in
+        // "Oxygen Not Included" and fails with ParameterBindingException.
+        let zip_s = zip.to_string_lossy().replace('\'', "''");
+        let dest_s = dest.to_string_lossy().replace('\'', "''");
+        let ps = format!(
+            "Expand-Archive -LiteralPath '{}' -DestinationPath '{}' -Force",
+            zip_s, dest_s
+        );
         let status = Command::new("powershell")
-            .args([
-                "-Command",
-                "Expand-Archive",
-                "-Path",
-                &zip.to_string_lossy(),
-                "-DestinationPath",
-                &dest.to_string_lossy(),
-                "-Force",
-            ])
+            .args(["-NoProfile", "-Command", &ps])
             .status()
             .context("解压失败（PowerShell Expand-Archive）")?;
         if !status.success() {

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::archive;
 use crate::build;
 use crate::config::{Config, SelectedMod};
 
@@ -41,7 +42,7 @@ pub fn run(cfg: &Config, selected: &SelectedMod) -> Result<()> {
     fs::create_dir_all(&dev_dir)
         .with_context(|| format!("创建 Dev 目录失败：{}", dev_dir.display()))?;
 
-    unzip(&zip, &dev_dir)?;
+    archive::unzip(&zip, &dev_dir)?;
     enable_dev_mod(cfg, selected, &dev_dir)?;
 
     println!("✅ 已安装到游戏 Dev 目录");
@@ -198,40 +199,6 @@ fn new_dev_mod_entry(selected: &SelectedMod, static_id: &str) -> Value {
      "reinstall_path": null,
      "staticID": static_id
     })
-}
-
-fn unzip(zip: &PathBuf, dest: &PathBuf) -> Result<()> {
-    #[cfg(target_os = "windows")]
-    {
-        // Quote paths: unquoted Expand-Archive splits on spaces in
-        // "Oxygen Not Included" and fails with ParameterBindingException.
-        let zip_s = zip.to_string_lossy().replace('\'', "''");
-        let dest_s = dest.to_string_lossy().replace('\'', "''");
-        let ps = format!(
-            "Expand-Archive -LiteralPath '{}' -DestinationPath '{}' -Force",
-            zip_s, dest_s
-        );
-        let status = Command::new("powershell")
-            .args(["-NoProfile", "-Command", &ps])
-            .status()
-            .context("解压失败（PowerShell Expand-Archive）")?;
-        if !status.success() {
-            anyhow::bail!("解压失败");
-        }
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        let status = Command::new("unzip")
-            .args(["-o", &zip.to_string_lossy(), "-d", &dest.to_string_lossy()])
-            .status()
-            .context("解压失败（unzip），请确认已安装 unzip")?;
-        if !status.success() {
-            anyhow::bail!("解压失败");
-        }
-    }
-
-    Ok(())
 }
 
 fn is_game_running() -> bool {

--- a/src/install.rs
+++ b/src/install.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
+use crate::archive;
 use crate::build;
 use crate::config::{Config, SelectedMod};
 
@@ -34,44 +34,10 @@ pub fn run(cfg: &Config, selected: &SelectedMod) -> Result<()> {
     fs::create_dir_all(&local_dir)
         .with_context(|| format!("创建 Local 目录失败：{}", local_dir.display()))?;
 
-    unzip(&zip, &local_dir)?;
+    archive::unzip(&zip, &local_dir)?;
 
     println!("✅ 已正式安装到游戏 Local 目录");
     println!("   启动游戏 → Mod 列表 → 启用 '{}'", selected.name);
-
-    Ok(())
-}
-
-fn unzip(zip: &PathBuf, dest: &PathBuf) -> Result<()> {
-    #[cfg(target_os = "windows")]
-    {
-        // Quote paths: unquoted Expand-Archive splits on spaces in
-        // "Oxygen Not Included" and fails with ParameterBindingException.
-        let zip_s = zip.to_string_lossy().replace('\'', "''");
-        let dest_s = dest.to_string_lossy().replace('\'', "''");
-        let ps = format!(
-            "Expand-Archive -LiteralPath '{}' -DestinationPath '{}' -Force",
-            zip_s, dest_s
-        );
-        let status = Command::new("powershell")
-            .args(["-NoProfile", "-Command", &ps])
-            .status()
-            .context("解压失败（PowerShell Expand-Archive）")?;
-        if !status.success() {
-            anyhow::bail!("解压失败");
-        }
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        let status = Command::new("unzip")
-            .args(["-o", &zip.to_string_lossy(), "-d", &dest.to_string_lossy()])
-            .status()
-            .context("解压失败（unzip），请确认已安装 unzip")?;
-        if !status.success() {
-            anyhow::bail!("解压失败");
-        }
-    }
 
     Ok(())
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -45,16 +45,16 @@ pub fn run(cfg: &Config, selected: &SelectedMod) -> Result<()> {
 fn unzip(zip: &PathBuf, dest: &PathBuf) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
+        // Quote paths: unquoted Expand-Archive splits on spaces in
+        // "Oxygen Not Included" and fails with ParameterBindingException.
+        let zip_s = zip.to_string_lossy().replace('\'', "''");
+        let dest_s = dest.to_string_lossy().replace('\'', "''");
+        let ps = format!(
+            "Expand-Archive -LiteralPath '{}' -DestinationPath '{}' -Force",
+            zip_s, dest_s
+        );
         let status = Command::new("powershell")
-            .args([
-                "-Command",
-                "Expand-Archive",
-                "-Path",
-                &zip.to_string_lossy(),
-                "-DestinationPath",
-                &dest.to_string_lossy(),
-                "-Force",
-            ])
+            .args(["-NoProfile", "-Command", &ps])
             .status()
             .context("解压失败（PowerShell Expand-Archive）")?;
         if !status.success() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
+mod archive;
 mod build;
 mod config;
 mod dev;

--- a/src/publish.rs
+++ b/src/publish.rs
@@ -36,7 +36,9 @@ fn uploader_path() -> Option<PathBuf> {
             "C:\\Program Files\\Steam\\steamapps\\common\\OxygenNotIncludedUploader\\OxygenNotIncludedUploader.exe",
         ] {
             let pb = PathBuf::from(p);
-            if pb.exists() { return Some(pb); }
+            if pb.exists() {
+                return Some(pb);
+            }
         }
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -38,9 +38,10 @@ fn auto_detect() -> Option<PathBuf> {
 
     #[cfg(target_os = "linux")]
     {
-        let p = PathBuf::from(&home)
-            .join(".local/share/Steam/steamapps/common/OxygenNotIncluded");
-        if p.join("OxygenNotIncluded_Data/Managed/Assembly-CSharp.dll").exists() {
+        let p = PathBuf::from(&home).join(".local/share/Steam/steamapps/common/OxygenNotIncluded");
+        if p.join("OxygenNotIncluded_Data/Managed/Assembly-CSharp.dll")
+            .exists()
+        {
             return Some(p);
         }
     }
@@ -49,8 +50,9 @@ fn auto_detect() -> Option<PathBuf> {
     {
         let p = PathBuf::from(&home)
             .join("Library/Application Support/Steam/steamapps/common/OxygenNotIncluded");
-        let mac_managed = p
-            .join("OxygenNotIncluded.app/Contents/OxygenNotIncluded_Data/Managed/Assembly-CSharp.dll");
+        let mac_managed = p.join(
+            "OxygenNotIncluded.app/Contents/OxygenNotIncluded_Data/Managed/Assembly-CSharp.dll",
+        );
         if mac_managed.exists() {
             return Some(p);
         }
@@ -63,7 +65,9 @@ fn auto_detect() -> Option<PathBuf> {
             "C:\\Program Files\\Steam\\steamapps\\common\\OxygenNotIncluded",
         ] {
             let p = PathBuf::from(base);
-            if p.join("OxygenNotIncluded_Data\\Managed\\Assembly-CSharp.dll").exists() {
+            if p.join("OxygenNotIncluded_Data\\Managed\\Assembly-CSharp.dll")
+                .exists()
+            {
                 return Some(p);
             }
         }
@@ -75,9 +79,12 @@ fn auto_detect() -> Option<PathBuf> {
 fn validate_game_path(path: &PathBuf) -> Result<Vec<String>> {
     let mut errors = vec![];
     let managed = if cfg!(target_os = "macos") {
-        let mac = path
-            .join("OxygenNotIncluded.app/Contents/OxygenNotIncluded_Data/Managed");
-        if mac.exists() { mac } else { path.join("OxygenNotIncluded_Data/Managed") }
+        let mac = path.join("OxygenNotIncluded.app/Contents/OxygenNotIncluded_Data/Managed");
+        if mac.exists() {
+            mac
+        } else {
+            path.join("OxygenNotIncluded_Data/Managed")
+        }
     } else if cfg!(target_os = "windows") {
         path.join("OxygenNotIncluded_Data\\Managed")
     } else {
@@ -217,8 +224,7 @@ path = "mods/OniModTemplate"
 "#;
 
     println!("\n📝 写入 {} ...", CONFIG_FILE);
-    fs::write(&config_path, toml_content)
-        .with_context(|| format!("写入 {} 失败", CONFIG_FILE))?;
+    fs::write(&config_path, toml_content).with_context(|| format!("写入 {} 失败", CONFIG_FILE))?;
 
     // 4. 写入 Directory.Build.props
     let sep = std::path::MAIN_SEPARATOR_STR;
@@ -242,12 +248,12 @@ path = "mods/OniModTemplate"
 </Project>
 "#,
         game_path.to_string_lossy().replace('"', "&quot;"),
-        sep, sep
+        sep,
+        sep
     );
 
     println!("📝 写入 {} ...", BUILD_PROPS);
-    fs::write(&props_path, props_content)
-        .with_context(|| format!("写入 {} 失败", BUILD_PROPS))?;
+    fs::write(&props_path, props_content).with_context(|| format!("写入 {} 失败", BUILD_PROPS))?;
 
     println!("\n✅ 初始化完成！");
     println!("   游戏路径：{}", game_path.display());


### PR DESCRIPTION
## Summary
- Prefer `Documents\Klei\OxygenNotIncluded` for Windows mod install when that `mods` tree exists (game loads Dev/Steam from there; LocalLow is mostly logs/config on this layout).
- Quote PowerShell `Expand-Archive -LiteralPath/-DestinationPath` so paths with spaces (`Oxygen Not Included`) no longer break `onim dev` / `onim install` after a successful build.
- Fix Windows `tar` quoting for the optional source tarball and do not fail the mod zip when that step errors.
- Add `scripts/install_onim.bat` (vcvars64 + `cargo install`) and `docs/WINDOWS_DEV.md`.

## Context
Collaborator push access confirmed. Same fix as the earlier fork PR, now on `LIghtJUNction/OniMods` branch `fix/windows-dev-deploy` for same-repo review/merge.

Hit while following the play → edit → `onim dev` → restart loop on Windows. Build succeeded but deploy failed or installed to a path the game did not load.

## Test plan
- [x] `cargo install --path .` (with MSVC vcvars) builds `onim`
- [x] `dotnet build` / `onim dev -m oni_mcp` produces `Documents\Klei\OxygenNotIncluded\mods\Dev\oni_mcp\` (OniMcp 0.2.1)
- [ ] Fresh Windows machine: `onim setup` + `onim dev -m oni_mcp`, restart ONI, confirm Player.log loads `...\mods\Dev\oni_mcp\OniMcp.dll`
- [ ] Disable Steam Workshop copy of the same staticID when testing Dev

## Summary by Sourcery

通过纠正游戏用户数据路径解析并加强用于模打包和安装的归档处理，修复 Windows 开发环境部署问题。

Bug Fixes:
- 通过在存在 `mods` 目录树时优先使用基于“文档”（Documents）的 Klei 目录，解决 Windows 模组安装路径错误问题。
- 通过为路径添加引号修复 Windows 上 PowerShell `Expand-Archive` 调用，使在《Oxygen Not Included》下的安装能够成功执行。
- 通过调整路径引用方式并在可选的源 `tarball` 步骤出错时避免模打包失败，改进 Windows 上的 `tar` 使用。

Enhancements:
- 添加一个 Windows 辅助脚本，用于在合适的 MSVC 环境中安装 `onim` CLI。

Documentation:
- 添加 Windows 相关的开发说明文档，记录模路径、归档问题以及 `onim` 开发时的验证步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Windows dev deployment by correcting game user data path resolution and hardening archive handling for mod packaging and installation.

Bug Fixes:
- Resolve incorrect Windows mod install path by preferring the Documents-based Klei directory when its mods tree exists.
- Fix PowerShell Expand-Archive invocation on Windows by quoting paths so installations under Oxygen Not Included succeed.
- Improve Windows tar usage by adjusting path quoting and avoiding mod packaging failures when the optional source tarball step errors.

Enhancements:
- Add a Windows helper script to install the onim CLI in a proper MSVC environment.

Documentation:
- Add Windows-specific development notes documenting mod paths, archive issues, and verification steps for onim dev.

</details>