### PR TITLE
fix(oni-mcp): Chinese query for priority set + storage detail

### DIFF
--- a/mods/oni_mcp/Tools/Impl/Build/StorageTargetResolver.cs
+++ b/mods/oni_mcp/Tools/Impl/Build/StorageTargetResolver.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace OniMcp.Tools
+{
+    public static partial class StorageTools
+    {
+        private static bool TryFindStorage(JObject args, out StorageInfo target, out string error)
+        {
+            target = null;
+            error = null;
+            int? id = ToolUtil.GetInt(args, "id");
+            int? x = ToolUtil.GetInt(args, "x");
+            int? y = ToolUtil.GetInt(args, "y");
+            if (x.HasValue != y.HasValue)
+            {
+                error = "x and y must be provided together";
+                return false;
+            }
+
+            int? cell = x.HasValue ? Grid.XYToCell(x.Value, y.Value) : (int?)null;
+            if (cell.HasValue && !Grid.IsValidCell(cell.Value))
+            {
+                error = "x/y does not resolve to a valid cell";
+                return false;
+            }
+
+            string query = args["query"]?.ToString();
+            if (string.IsNullOrWhiteSpace(query))
+                query = args["name"]?.ToString();
+            query = string.IsNullOrWhiteSpace(query) ? null : query.Trim();
+
+            bool hasStrongSelector = id.HasValue || cell.HasValue;
+            if (!hasStrongSelector && string.IsNullOrEmpty(query))
+            {
+                error = "id, x/y, query, or name is required";
+                return false;
+            }
+
+            int? explicitWorldId = ToolUtil.GetInt(args, "worldId");
+            int worldId = explicitWorldId ?? (hasStrongSelector ? -1 : ToolUtil.ResolveWorldId(args));
+            var candidates = GetStorageBuildings()
+                .Where(item => worldId < 0 || item.WorldId == worldId)
+                .ToList();
+            if (hasStrongSelector)
+            {
+                var selected = candidates
+                    .Where(item => !id.HasValue || item.Id == id.Value)
+                    .Where(item => !cell.HasValue || item.Cell == cell.Value)
+                    .ToList();
+                if (selected.Count == 0)
+                {
+                    error = id.HasValue && cell.HasValue
+                        ? "id and x/y selectors do not resolve to the same storage building"
+                        : "Storage building not found for the supplied selector";
+                    return false;
+                }
+                if (selected.Count > 1)
+                {
+                    error = "Storage selector is ambiguous. Candidates: " + StorageTargetHints(selected);
+                    return false;
+                }
+                if (!string.IsNullOrEmpty(query) && !selected[0].MatchesIdentity(query))
+                {
+                    error = "query/name does not match the storage building selected by id/x/y";
+                    return false;
+                }
+
+                target = selected[0];
+                return true;
+            }
+
+            var matches = candidates.Where(item => item.MatchesIdentity(query)).ToList();
+            if (matches.Count == 0)
+            {
+                error = "Storage building not found for query in world " + worldId;
+                return false;
+            }
+            if (matches.Count > 1)
+            {
+                error = "Storage query is ambiguous. Candidates: " + StorageTargetHints(matches);
+                return false;
+            }
+
+            target = matches[0];
+            return true;
+        }
+
+        private static string StorageTargetHints(IEnumerable<StorageInfo> candidates)
+        {
+            return string.Join("; ", candidates.Take(5).Select(item =>
+                $"id={item.Id}, name={item.Name}, prefabId={item.PrefabId}, x={item.X}, y={item.Y}"));
+        }
+    }
+}

--- a/mods/oni_mcp/Tools/Impl/Build/StorageTools.cs
+++ b/mods/oni_mcp/Tools/Impl/Build/StorageTools.cs
@@ -8,7 +8,7 @@ using OniMcp.Support;
 
 namespace OniMcp.Tools
 {
-    public static class StorageTools
+    public static partial class StorageTools
     {
         public static McpTool GetStorageList()
         {
@@ -64,9 +64,10 @@ namespace OniMcp.Tools
                 Parameters = StorageLookupParams(),
                 Handler = args =>
                 {
-                    var target = FindStorage(args);
-                    if (target == null)
-                        return CallToolResult.Error("Storage building not found");
+                    StorageInfo target;
+                    string error;
+                    if (!TryFindStorage(args, out target, out error))
+                        return CallToolResult.Error(error);
                     return CallToolResult.Text(JsonConvert.SerializeObject(target.ToDictionary(includeItems: true), McpJsonUtil.Settings));
                 }
             };
@@ -82,19 +83,17 @@ namespace OniMcp.Tools
                 Mode = "write",
                 Risk = "medium",
                 Description = "兼容入口：请优先使用 building_control domain=storage action=set_filter。设置储存建筑的资源过滤标签；默认替换当前过滤器，也可 add/remove",
-                Parameters = new Dictionary<string, McpToolParameter>
+                Parameters = StorageLookupParams(new Dictionary<string, McpToolParameter>
                 {
-                    ["id"] = new McpToolParameter { Type = "integer", Description = "建筑 InstanceID", Required = false },
-                    ["x"] = new McpToolParameter { Type = "integer", Description = "建筑所在格子 X", Required = false },
-                    ["y"] = new McpToolParameter { Type = "integer", Description = "建筑所在格子 Y", Required = false },
                     ["tags"] = new McpToolParameter { Type = "array", Description = "资源 Tag 列表，如 Dirt、Algae、SandStone", Required = true },
                     ["mode"] = new McpToolParameter { Type = "string", Description = "replace、add、remove，默认 replace", Required = false, EnumValues = new List<string> { "replace", "add", "remove" } }
-                },
+                }),
                 Handler = args =>
                 {
-                    var target = FindStorage(args);
-                    if (target == null)
-                        return CallToolResult.Error("Storage building not found");
+                    StorageInfo target;
+                    string error;
+                    if (!TryFindStorage(args, out target, out error))
+                        return CallToolResult.Error(error);
 
                     var filterable = target.GameObject.GetComponent<TreeFilterable>();
                     if (filterable == null)
@@ -139,7 +138,7 @@ namespace OniMcp.Tools
                 {
                     ["action"] = new McpToolParameter { Type = "string", Description = "list、detail 或 set_filter", Required = true, EnumValues = new List<string> { "list", "detail", "set_filter" } },
                     ["resource"] = new McpToolParameter { Type = "string", Description = "action=list 时按储存过滤标签或建筑名筛选", Required = false },
-                    ["worldId"] = new McpToolParameter { Type = "integer", Description = "action=list 时按世界 ID 过滤", Required = false },
+                    ["worldId"] = new McpToolParameter { Type = "integer", Description = "目标世界 ID；detail/set_filter 的 query-only 默认当前激活世界", Required = false },
                     ["limit"] = new McpToolParameter { Type = "integer", Description = "action=list 时最多返回数量，默认 100，最大 500", Required = false },
                     ["id"] = new McpToolParameter { Type = "integer", Description = "action=detail/set_filter 时的建筑 InstanceID", Required = false },
                     ["x"] = new McpToolParameter { Type = "integer", Description = "action=detail/set_filter 时的建筑所在格子 X", Required = false },
@@ -244,31 +243,23 @@ namespace OniMcp.Tools
             };
         }
 
-        private static Dictionary<string, McpToolParameter> StorageLookupParams()
+        private static Dictionary<string, McpToolParameter> StorageLookupParams(Dictionary<string, McpToolParameter> extra = null)
         {
-            return new Dictionary<string, McpToolParameter>
+            var parameters = new Dictionary<string, McpToolParameter>
             {
                 ["id"] = new McpToolParameter { Type = "integer", Description = "建筑 InstanceID", Required = false },
                 ["x"] = new McpToolParameter { Type = "integer", Description = "建筑所在格子 X", Required = false },
                 ["y"] = new McpToolParameter { Type = "integer", Description = "建筑所在格子 Y", Required = false },
                 ["query"] = new McpToolParameter { Type = "string", Description = "按本地化建筑名或 prefabId 查找，如 洗手盆 / WashBasin", Required = false },
-                ["name"] = new McpToolParameter { Type = "string", Description = "query 的别名", Required = false }
+                ["name"] = new McpToolParameter { Type = "string", Description = "query 的别名", Required = false },
+                ["worldId"] = new McpToolParameter { Type = "integer", Description = "目标世界 ID；query-only 默认当前激活世界", Required = false }
             };
-        }
-
-        private static StorageInfo FindStorage(Newtonsoft.Json.Linq.JObject args)
-        {
-            int? id = ToolUtil.GetInt(args, "id");
-            int? x = ToolUtil.GetInt(args, "x");
-            int? y = ToolUtil.GetInt(args, "y");
-            int? cell = x.HasValue && y.HasValue ? Grid.XYToCell(x.Value, y.Value) : (int?)null;
-            string query = args["query"]?.ToString() ?? args["name"]?.ToString() ?? args["resource"]?.ToString();
-            string filter = string.IsNullOrWhiteSpace(query) ? null : query.Trim().ToLowerInvariant();
-
-            return GetStorageBuildings().FirstOrDefault(item =>
-                (id.HasValue && item.Id == id.Value) ||
-                (cell.HasValue && item.Cell == cell.Value) ||
-                (!string.IsNullOrEmpty(filter) && item.Matches(filter)));
+            if (extra != null)
+            {
+                foreach (var item in extra)
+                    parameters[item.Key] = item.Value;
+            }
+            return parameters;
         }
 
         private static List<StorageInfo> GetStorageBuildings()
@@ -350,6 +341,12 @@ namespace OniMcp.Tools
                 return Name.ToLowerInvariant().Contains(filter) ||
                        PrefabId.ToLowerInvariant().Contains(filter) ||
                        AcceptedTags.Any(tag => tag.ToLowerInvariant().Contains(filter));
+            }
+
+            public bool MatchesIdentity(string query)
+            {
+                return Name.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                       PrefabId.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
             }
 
             public Dictionary<string, object> ToDictionary(bool includeItems)

--- a/mods/oni_mcp/Tools/Impl/Build/StorageTools.cs
+++ b/mods/oni_mcp/Tools/Impl/Build/StorageTools.cs
@@ -144,6 +144,8 @@ namespace OniMcp.Tools
                     ["id"] = new McpToolParameter { Type = "integer", Description = "action=detail/set_filter 时的建筑 InstanceID", Required = false },
                     ["x"] = new McpToolParameter { Type = "integer", Description = "action=detail/set_filter 时的建筑所在格子 X", Required = false },
                     ["y"] = new McpToolParameter { Type = "integer", Description = "action=detail/set_filter 时的建筑所在格子 Y", Required = false },
+                    ["query"] = new McpToolParameter { Type = "string", Description = "action=detail/set_filter 时按本地化名或 prefabId 查找", Required = false },
+                    ["name"] = new McpToolParameter { Type = "string", Description = "query 的别名", Required = false },
                     ["tags"] = new McpToolParameter { Type = "array", Description = "action=set_filter 时资源 Tag 列表，如 Dirt、Algae、SandStone", Required = false },
                     ["mode"] = new McpToolParameter { Type = "string", Description = "action=set_filter 时为 replace、add、remove，默认 replace", Required = false, EnumValues = new List<string> { "replace", "add", "remove" } }
                 },
@@ -248,7 +250,9 @@ namespace OniMcp.Tools
             {
                 ["id"] = new McpToolParameter { Type = "integer", Description = "建筑 InstanceID", Required = false },
                 ["x"] = new McpToolParameter { Type = "integer", Description = "建筑所在格子 X", Required = false },
-                ["y"] = new McpToolParameter { Type = "integer", Description = "建筑所在格子 Y", Required = false }
+                ["y"] = new McpToolParameter { Type = "integer", Description = "建筑所在格子 Y", Required = false },
+                ["query"] = new McpToolParameter { Type = "string", Description = "按本地化建筑名或 prefabId 查找，如 洗手盆 / WashBasin", Required = false },
+                ["name"] = new McpToolParameter { Type = "string", Description = "query 的别名", Required = false }
             };
         }
 
@@ -258,10 +262,13 @@ namespace OniMcp.Tools
             int? x = ToolUtil.GetInt(args, "x");
             int? y = ToolUtil.GetInt(args, "y");
             int? cell = x.HasValue && y.HasValue ? Grid.XYToCell(x.Value, y.Value) : (int?)null;
+            string query = args["query"]?.ToString() ?? args["name"]?.ToString() ?? args["resource"]?.ToString();
+            string filter = string.IsNullOrWhiteSpace(query) ? null : query.Trim().ToLowerInvariant();
 
             return GetStorageBuildings().FirstOrDefault(item =>
                 (id.HasValue && item.Id == id.Value) ||
-                (cell.HasValue && item.Cell == cell.Value));
+                (cell.HasValue && item.Cell == cell.Value) ||
+                (!string.IsNullOrEmpty(filter) && item.Matches(filter)));
         }
 
         private static List<StorageInfo> GetStorageBuildings()

--- a/mods/oni_mcp/Tools/Impl/Orders/OrdersPriorityTargetResolver.cs
+++ b/mods/oni_mcp/Tools/Impl/Orders/OrdersPriorityTargetResolver.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+
+namespace OniMcp.Tools
+{
+    public static partial class OrdersTools
+    {
+        private static bool TryFindPriorityTarget(JObject args, out GameObject target, out string error)
+        {
+            target = null;
+            error = null;
+            int? id = ToolUtil.GetInt(args, "id");
+            int? x = ToolUtil.GetInt(args, "x");
+            int? y = ToolUtil.GetInt(args, "y");
+            if (x.HasValue != y.HasValue)
+            {
+                error = "x and y must be provided together";
+                return false;
+            }
+
+            int? cell = x.HasValue ? Grid.XYToCell(x.Value, y.Value) : (int?)null;
+            if (cell.HasValue && !Grid.IsValidCell(cell.Value))
+            {
+                error = "x/y does not resolve to a valid cell";
+                return false;
+            }
+
+            string query = FirstNonEmpty(args, "query", "target", "search");
+            bool hasStrongSelector = id.HasValue || cell.HasValue;
+            if (!hasStrongSelector && string.IsNullOrEmpty(query))
+            {
+                error = "id, x/y, or query is required";
+                return false;
+            }
+
+            int? explicitWorldId = ToolUtil.GetInt(args, "worldId");
+            int worldId = explicitWorldId ?? (hasStrongSelector ? -1 : ToolUtil.ResolveWorldId(args));
+            var candidates = PriorityTargetCandidates(worldId);
+            if (hasStrongSelector)
+            {
+                var selected = candidates
+                    .Where(go => !id.HasValue || PriorityTargetId(go) == id.Value)
+                    .Where(go => !cell.HasValue || Grid.PosToCell(go) == cell.Value)
+                    .ToList();
+                if (selected.Count == 0)
+                {
+                    error = id.HasValue && cell.HasValue
+                        ? "id and x/y selectors do not resolve to the same target"
+                        : "Target not found for the supplied selector";
+                    return false;
+                }
+                if (selected.Count > 1)
+                {
+                    error = "Target selector is ambiguous. Candidates: " + PriorityTargetHints(selected);
+                    return false;
+                }
+                if (!string.IsNullOrEmpty(query) && !MatchesQuery(selected[0], query))
+                {
+                    error = "query does not match the target selected by id/x/y";
+                    return false;
+                }
+
+                target = selected[0];
+                return true;
+            }
+
+            var matches = candidates.Where(go => MatchesQuery(go, query)).ToList();
+            if (matches.Count == 0)
+            {
+                error = "Target not found for query in world " + worldId;
+                return false;
+            }
+            if (matches.Count > 1)
+            {
+                error = "Target query is ambiguous. Candidates: " + PriorityTargetHints(matches);
+                return false;
+            }
+
+            target = matches[0];
+            return true;
+        }
+
+        private static List<GameObject> PriorityTargetCandidates(int worldId)
+        {
+            var result = new List<GameObject>();
+            var seen = new HashSet<int>();
+            Action<GameObject> add = go =>
+            {
+                if (go == null || !ToolUtil.GameObjectMatchesWorld(go, worldId) || !seen.Add(go.GetInstanceID()))
+                    return;
+                result.Add(go);
+            };
+
+            foreach (var prioritizable in Components.Prioritizables.Items)
+                add(prioritizable?.gameObject);
+            foreach (var building in Components.BuildingCompletes.Items)
+                add(building?.gameObject);
+            return result.OrderBy(PriorityTargetId).ToList();
+        }
+
+        private static int PriorityTargetId(GameObject go)
+        {
+            return go.GetComponent<KPrefabID>()?.InstanceID ?? go.GetInstanceID();
+        }
+
+        private static string PriorityTargetHints(IEnumerable<GameObject> candidates)
+        {
+            return string.Join("; ", candidates.Take(5).Select(go =>
+            {
+                int cell = Grid.PosToCell(go);
+                int x = Grid.IsValidCell(cell) ? Grid.CellColumn(cell) : -1;
+                int y = Grid.IsValidCell(cell) ? Grid.CellRow(cell) : -1;
+                string prefabId = go.GetComponent<KPrefabID>()?.PrefabTag.Name ?? go.name;
+                return $"id={PriorityTargetId(go)}, name={ToolUtil.CleanName(go.GetProperName())}, prefabId={prefabId}, x={x}, y={y}";
+            }));
+        }
+
+        private static string FirstNonEmpty(JObject args, params string[] keys)
+        {
+            foreach (string key in keys)
+            {
+                string value = args[key]?.ToString();
+                if (!string.IsNullOrWhiteSpace(value))
+                    return value.Trim();
+            }
+            return null;
+        }
+    }
+}

--- a/mods/oni_mcp/Tools/Impl/Orders/OrdersPriorityTools.cs
+++ b/mods/oni_mcp/Tools/Impl/Orders/OrdersPriorityTools.cs
@@ -80,9 +80,10 @@ namespace OniMcp.Tools
                 }),
                 Handler = args =>
                 {
-                    var go = FindTarget(args);
-                    if (go == null)
-                        return CallToolResult.Error("Target not found");
+                    GameObject go;
+                    string error;
+                    if (!TryFindPriorityTarget(args, out go, out error))
+                        return CallToolResult.Error(error);
                     var prioritizable = go.GetComponent<Prioritizable>();
                     if (prioritizable == null)
                         return CallToolResult.Error("Target is not prioritizable");
@@ -181,7 +182,7 @@ namespace OniMcp.Tools
                     ["y"] = new McpToolParameter { Type = "integer", Description = "action=set_building 时的目标格子 Y", Required = false },
                     ["priority"] = new McpToolParameter { Type = "integer", Description = "action=set_building/set_area 时的优先级 1-9", Required = false },
                     ["topPriority"] = new McpToolParameter { Type = "boolean", Description = "action=set_building/set_area 时是否设为红色最高优先级，默认 false", Required = false },
-                    ["query"] = new McpToolParameter { Type = "string", Description = "action=list/set_area 时按名称或 prefabId 关键词筛选", Required = false },
+                    ["query"] = new McpToolParameter { Type = "string", Description = "action=list/set_building/set_area 时按名称或 prefabId 关键词筛选", Required = false },
                     ["includeInactive"] = new McpToolParameter { Type = "boolean", Description = "action=list/set_area 时是否包含当前不可设置优先级的对象，默认 false", Required = false },
                     ["limit"] = new McpToolParameter { Type = "integer", Description = "action=list/set_area 时最多返回或修改数量", Required = false },
                     ["confirm"] = new McpToolParameter { Type = "boolean", Description = "action=set_area 且区域超过 100 格时必须为 true", Required = false }
@@ -207,12 +208,12 @@ namespace OniMcp.Tools
             ["id"] = new McpToolParameter { Type = "integer", Description = "目标对象 InstanceID", Required = false },
             ["x"] = new McpToolParameter { Type = "integer", Description = "目标格子 X；省略时可用 query/target/search 搜索定位", Required = false },
             ["y"] = new McpToolParameter { Type = "integer", Description = "目标格子 Y；省略时可用 query/target/search 搜索定位", Required = false },
-            ["query"] = new McpToolParameter { Type = "string", Description = "按对象名称、prefabId、元素或复制人搜索目标格", Required = false },
+            ["query"] = new McpToolParameter { Type = "string", Description = "按对象名称或 prefabId 搜索；多个匹配会报错并要求使用 id/x/y", Required = false },
             ["target"] = new McpToolParameter { Type = "string", Description = "query 的别名", Required = false },
             ["search"] = new McpToolParameter { Type = "string", Description = "query 的别名", Required = false },
-            ["nearX"] = new McpToolParameter { Type = "integer", Description = "搜索定位时按距该 X 最近排序", Required = false },
-            ["nearY"] = new McpToolParameter { Type = "integer", Description = "搜索定位时按距该 Y 最近排序", Required = false },
-            ["worldId"] = new McpToolParameter { Type = "integer", Description = "目标世界 ID；按坐标查找时默认当前激活世界", Required = false }
+            ["nearX"] = new McpToolParameter { Type = "integer", Description = "兼容参数；不用于自动消除多目标歧义，请改用 id/x/y", Required = false },
+            ["nearY"] = new McpToolParameter { Type = "integer", Description = "兼容参数；不用于自动消除多目标歧义，请改用 id/x/y", Required = false },
+            ["worldId"] = new McpToolParameter { Type = "integer", Description = "目标世界 ID，默认当前激活世界", Required = false }
         };
             foreach (var item in extra)
                 parameters[item.Key] = item.Value;
@@ -233,87 +234,6 @@ namespace OniMcp.Tools
             foreach (var item in extra)
                 parameters[item.Key] = item.Value;
             return parameters;
-        }
-
-        private static GameObject FindTarget(Newtonsoft.Json.Linq.JObject args)
-        {
-            int? id = ToolUtil.GetInt(args, "id");
-            int? x = ToolUtil.GetInt(args, "x");
-            int? y = ToolUtil.GetInt(args, "y");
-            // Keep original casing for MatchesQuery / CleanName (Chinese display names).
-            string queryRaw = args["query"]?.ToString()?.Trim();
-            string query = string.IsNullOrEmpty(queryRaw) ? null : queryRaw.ToLowerInvariant();
-            bool explicitCell = x.HasValue && y.HasValue;
-            int? cell = explicitCell ? Grid.XYToCell(x.Value, y.Value) : (int?)null;
-            // Live bug: TryResolveSearchCell("研究站") can resolve a wrong cell. Then the
-            // cell-scoped loop runs, finds nothing matching the Chinese query, and returns
-            // null without ever using CleanName matching. Prefer name matching when the
-            // caller only passed query (no explicit id/x/y).
-            if (!cell.HasValue && string.IsNullOrEmpty(queryRaw))
-            {
-                int searchX;
-                int searchY;
-                string searchError;
-                if (ToolUtil.TryResolveSearchCell(args, out searchX, out searchY, out searchError))
-                    cell = Grid.XYToCell(searchX, searchY);
-            }
-            int worldId = cell.HasValue ? ToolUtil.ResolveWorldId(args) : (ToolUtil.GetInt(args, "worldId") ?? -1);
-
-            foreach (var prioritizable in Components.Prioritizables.Items)
-            {
-                var go = prioritizable?.gameObject;
-                if (go == null) continue;
-                if (!ToolUtil.GameObjectMatchesWorld(go, worldId)) continue;
-                var kpid = go.GetComponent<KPrefabID>();
-                if (id.HasValue && kpid != null && kpid.InstanceID == id.Value)
-                    return go;
-                if (cell.HasValue && Grid.PosToCell(go) == cell.Value)
-                {
-                    if (!string.IsNullOrEmpty(queryRaw) && !MatchesQuery(go, queryRaw))
-                        continue;
-                    return go;
-                }
-            }
-
-            foreach (var building in Components.BuildingCompletes.Items)
-            {
-                var go = building?.gameObject;
-                if (go == null) continue;
-                if (!ToolUtil.GameObjectMatchesWorld(go, worldId)) continue;
-                var kpid = go.GetComponent<KPrefabID>();
-                if (id.HasValue && kpid != null && kpid.InstanceID == id.Value)
-                    return go;
-                if (cell.HasValue && Grid.PosToCell(go) == cell.Value)
-                {
-                    if (!string.IsNullOrEmpty(queryRaw) && !MatchesQuery(go, queryRaw))
-                        continue;
-                    return go;
-                }
-            }
-
-            // query-only (or query after failed cell filter): match CleanName / prefabId like list.
-            if (!id.HasValue && !string.IsNullOrEmpty(queryRaw))
-            {
-                foreach (var prioritizable in Components.Prioritizables.Items)
-                {
-                    var go = prioritizable?.gameObject;
-                    if (go == null) continue;
-                    if (!ToolUtil.GameObjectMatchesWorld(go, worldId)) continue;
-                    if (MatchesQuery(go, queryRaw))
-                        return go;
-                }
-
-                foreach (var building in Components.BuildingCompletes.Items)
-                {
-                    var go = building?.gameObject;
-                    if (go == null) continue;
-                    if (!ToolUtil.GameObjectMatchesWorld(go, worldId)) continue;
-                    if (MatchesQuery(go, queryRaw))
-                        return go;
-                }
-            }
-
-            return null;
         }
 
         private static PrioritySetting ParsePrioritySetting(Newtonsoft.Json.Linq.JObject args)

--- a/mods/oni_mcp/Tools/Impl/Orders/OrdersPriorityTools.cs
+++ b/mods/oni_mcp/Tools/Impl/Orders/OrdersPriorityTools.cs
@@ -243,8 +243,13 @@ namespace OniMcp.Tools
             // Keep original casing for MatchesQuery / CleanName (Chinese display names).
             string queryRaw = args["query"]?.ToString()?.Trim();
             string query = string.IsNullOrEmpty(queryRaw) ? null : queryRaw.ToLowerInvariant();
-            int? cell = x.HasValue && y.HasValue ? Grid.XYToCell(x.Value, y.Value) : (int?)null;
-            if (!cell.HasValue)
+            bool explicitCell = x.HasValue && y.HasValue;
+            int? cell = explicitCell ? Grid.XYToCell(x.Value, y.Value) : (int?)null;
+            // Live bug: TryResolveSearchCell("研究站") can resolve a wrong cell. Then the
+            // cell-scoped loop runs, finds nothing matching the Chinese query, and returns
+            // null without ever using CleanName matching. Prefer name matching when the
+            // caller only passed query (no explicit id/x/y).
+            if (!cell.HasValue && string.IsNullOrEmpty(queryRaw))
             {
                 int searchX;
                 int searchY;
@@ -264,7 +269,7 @@ namespace OniMcp.Tools
                     return go;
                 if (cell.HasValue && Grid.PosToCell(go) == cell.Value)
                 {
-                    if (!string.IsNullOrEmpty(query) && !go.name.ToLowerInvariant().Contains(query) && (kpid == null || !kpid.PrefabTag.Name.ToLowerInvariant().Contains(query)) && !MatchesQuery(go, queryRaw))
+                    if (!string.IsNullOrEmpty(queryRaw) && !MatchesQuery(go, queryRaw))
                         continue;
                     return go;
                 }
@@ -280,15 +285,14 @@ namespace OniMcp.Tools
                     return go;
                 if (cell.HasValue && Grid.PosToCell(go) == cell.Value)
                 {
-                    if (!string.IsNullOrEmpty(query) && !go.name.ToLowerInvariant().Contains(query) && (kpid == null || !kpid.PrefabTag.Name.ToLowerInvariant().Contains(query)) && !MatchesQuery(go, queryRaw))
+                    if (!string.IsNullOrEmpty(queryRaw) && !MatchesQuery(go, queryRaw))
                         continue;
                     return go;
                 }
             }
 
-            // query-only: match localized CleanName / prefabId the same way list does.
-            // Without this, Chinese names like "研究站" fail while English prefab "ResearchCenter" may still resolve via TryResolveSearchCell.
-            if (!id.HasValue && !cell.HasValue && !string.IsNullOrEmpty(queryRaw))
+            // query-only (or query after failed cell filter): match CleanName / prefabId like list.
+            if (!id.HasValue && !string.IsNullOrEmpty(queryRaw))
             {
                 foreach (var prioritizable in Components.Prioritizables.Items)
                 {

--- a/mods/oni_mcp/Tools/Impl/Orders/OrdersPriorityTools.cs
+++ b/mods/oni_mcp/Tools/Impl/Orders/OrdersPriorityTools.cs
@@ -240,7 +240,9 @@ namespace OniMcp.Tools
             int? id = ToolUtil.GetInt(args, "id");
             int? x = ToolUtil.GetInt(args, "x");
             int? y = ToolUtil.GetInt(args, "y");
-            string query = args["query"]?.ToString()?.Trim().ToLowerInvariant();
+            // Keep original casing for MatchesQuery / CleanName (Chinese display names).
+            string queryRaw = args["query"]?.ToString()?.Trim();
+            string query = string.IsNullOrEmpty(queryRaw) ? null : queryRaw.ToLowerInvariant();
             int? cell = x.HasValue && y.HasValue ? Grid.XYToCell(x.Value, y.Value) : (int?)null;
             if (!cell.HasValue)
             {
@@ -262,7 +264,7 @@ namespace OniMcp.Tools
                     return go;
                 if (cell.HasValue && Grid.PosToCell(go) == cell.Value)
                 {
-                    if (!string.IsNullOrEmpty(query) && !go.name.ToLowerInvariant().Contains(query) && (kpid == null || !kpid.PrefabTag.Name.ToLowerInvariant().Contains(query)))
+                    if (!string.IsNullOrEmpty(query) && !go.name.ToLowerInvariant().Contains(query) && (kpid == null || !kpid.PrefabTag.Name.ToLowerInvariant().Contains(query)) && !MatchesQuery(go, queryRaw))
                         continue;
                     return go;
                 }
@@ -278,9 +280,32 @@ namespace OniMcp.Tools
                     return go;
                 if (cell.HasValue && Grid.PosToCell(go) == cell.Value)
                 {
-                    if (!string.IsNullOrEmpty(query) && !go.name.ToLowerInvariant().Contains(query) && (kpid == null || !kpid.PrefabTag.Name.ToLowerInvariant().Contains(query)))
+                    if (!string.IsNullOrEmpty(query) && !go.name.ToLowerInvariant().Contains(query) && (kpid == null || !kpid.PrefabTag.Name.ToLowerInvariant().Contains(query)) && !MatchesQuery(go, queryRaw))
                         continue;
                     return go;
+                }
+            }
+
+            // query-only: match localized CleanName / prefabId the same way list does.
+            // Without this, Chinese names like "研究站" fail while English prefab "ResearchCenter" may still resolve via TryResolveSearchCell.
+            if (!id.HasValue && !cell.HasValue && !string.IsNullOrEmpty(queryRaw))
+            {
+                foreach (var prioritizable in Components.Prioritizables.Items)
+                {
+                    var go = prioritizable?.gameObject;
+                    if (go == null) continue;
+                    if (!ToolUtil.GameObjectMatchesWorld(go, worldId)) continue;
+                    if (MatchesQuery(go, queryRaw))
+                        return go;
+                }
+
+                foreach (var building in Components.BuildingCompletes.Items)
+                {
+                    var go = building?.gameObject;
+                    if (go == null) continue;
+                    if (!ToolUtil.GameObjectMatchesWorld(go, worldId)) continue;
+                    if (MatchesQuery(go, queryRaw))
+                        return go;
                 }
             }
 

--- a/mods/oni_mcp/Tools/Impl/Orders/OrdersSharedTargetingTools.cs
+++ b/mods/oni_mcp/Tools/Impl/Orders/OrdersSharedTargetingTools.cs
@@ -46,5 +46,79 @@ namespace OniMcp.Tools
                     var component = go.GetComponent<KMonoBehaviour>();
                     return component != null ? component.GetMyWorldId() : -1;
                 }
+
+                private static GameObject FindTarget(JObject args)
+                {
+                    int? id = ToolUtil.GetInt(args, "id");
+                    int? x = ToolUtil.GetInt(args, "x");
+                    int? y = ToolUtil.GetInt(args, "y");
+                    string queryRaw = args["query"]?.ToString()?.Trim();
+                    bool explicitCell = x.HasValue && y.HasValue;
+                    int? cell = explicitCell ? Grid.XYToCell(x.Value, y.Value) : (int?)null;
+                    if (!cell.HasValue && string.IsNullOrEmpty(queryRaw))
+                    {
+                        int searchX;
+                        int searchY;
+                        string searchError;
+                        if (ToolUtil.TryResolveSearchCell(args, out searchX, out searchY, out searchError))
+                            cell = Grid.XYToCell(searchX, searchY);
+                    }
+                    int worldId = cell.HasValue ? ToolUtil.ResolveWorldId(args) : (ToolUtil.GetInt(args, "worldId") ?? -1);
+
+                    foreach (var prioritizable in Components.Prioritizables.Items)
+                    {
+                        var go = prioritizable?.gameObject;
+                        if (go == null) continue;
+                        if (!ToolUtil.GameObjectMatchesWorld(go, worldId)) continue;
+                        var kpid = go.GetComponent<KPrefabID>();
+                        if (id.HasValue && kpid != null && kpid.InstanceID == id.Value)
+                            return go;
+                        if (cell.HasValue && Grid.PosToCell(go) == cell.Value)
+                        {
+                            if (!string.IsNullOrEmpty(queryRaw) && !MatchesQuery(go, queryRaw))
+                                continue;
+                            return go;
+                        }
+                    }
+
+                    foreach (var building in Components.BuildingCompletes.Items)
+                    {
+                        var go = building?.gameObject;
+                        if (go == null) continue;
+                        if (!ToolUtil.GameObjectMatchesWorld(go, worldId)) continue;
+                        var kpid = go.GetComponent<KPrefabID>();
+                        if (id.HasValue && kpid != null && kpid.InstanceID == id.Value)
+                            return go;
+                        if (cell.HasValue && Grid.PosToCell(go) == cell.Value)
+                        {
+                            if (!string.IsNullOrEmpty(queryRaw) && !MatchesQuery(go, queryRaw))
+                                continue;
+                            return go;
+                        }
+                    }
+
+                    if (!id.HasValue && !string.IsNullOrEmpty(queryRaw))
+                    {
+                        foreach (var prioritizable in Components.Prioritizables.Items)
+                        {
+                            var go = prioritizable?.gameObject;
+                            if (go == null) continue;
+                            if (!ToolUtil.GameObjectMatchesWorld(go, worldId)) continue;
+                            if (MatchesQuery(go, queryRaw))
+                                return go;
+                        }
+
+                        foreach (var building in Components.BuildingCompletes.Items)
+                        {
+                            var go = building?.gameObject;
+                            if (go == null) continue;
+                            if (!ToolUtil.GameObjectMatchesWorld(go, worldId)) continue;
+                            if (MatchesQuery(go, queryRaw))
+                                return go;
+                        }
+                    }
+
+                    return null;
+                }
     }
 }


### PR DESCRIPTION
## Summary
- `orders_control domain=priority action=set_building query=<中文名>` now resolves buildings via the same `CleanName`/`MatchesQuery` path as `list` (query-only, no id/cell required).
- `building_control domain=storage action=detail|set_filter` accepts `query`/`name` (and schema documents it), not only `id`/`x`/`y`.
- Windows optional source `tar` packaging no longer fails the mod zip build.

## Live repro (羽书殖民地, zh-CN, Dev mod)
| Call | Before | After (intended) |
|------|--------|------------------|
| `priority set_building query=研究站 priority=8` | `Target not found` | sets priority |
| `priority set_building query=ResearchCenter` | works | works |
| `priority list query=研究` | returns 研究站 | unchanged |
| `storage detail query=洗手盆` | `Storage building not found` | returns storage |
| `storage detail id=...` | works | works |

## Why it matters for agents
Localized UIs surface Chinese names in notifications/snapshots. Agents pass those into `query`. list succeeding while set fails is an inconsistent contract and burns retries.

## Test plan
- [x] `dotnet build mods/oni_mcp/OniMcp.csproj` succeeds with local `Directory.Build.props`
- [ ] `onim dev -m oni_mcp` + restart ONI
- [ ] Repro table above on a zh-CN save
- [ ] English prefab queries still work

## Summary by Sourcery

改进 oni_mcp 的建筑查找逻辑，使优先级和存储控制在处理本地化查询时更加可靠，并修复影响 Windows 模组构建的打包问题。

新特性：
- 允许存储控制的 detail/set_filter 操作通过 query/name 参数，根据建筑的本地化名称或 prefabId 进行定位。

缺陷修复：
- 修复 priority 的 set_building，在仅使用 query 的请求时也能通过本地化名称和 prefabId 解析建筑对象，使其行为与 list 保持一致。

改进：
- 在 MCP 模式(schema)中为存储工具记录 query/name 参数，便于代理更清晰地使用。

构建：
- 调整 OniMcp 项目的打包逻辑，使可选的 Windows 源码 tar 生成不再破坏模组 zip 的构建流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve oni_mcp building lookup so priority and storage controls reliably handle localized queries, and fix packaging issues affecting Windows mod builds.

New Features:
- Allow storage control detail/set_filter actions to target buildings by localized name or prefabId via query/name parameters.

Bug Fixes:
- Fix priority set_building to resolve buildings by localized names and prefabIds when using query-only requests, aligning behavior with list.

Enhancements:
- Document query/name parameters for storage tools in the MCP schema for clearer agent usage.

Build:
- Adjust OniMcp project packaging so optional Windows source tar generation no longer breaks mod zip builds.

</details>