### PR TITLE
fix(oni-mcp): bound virtual map layer requests

### DIFF
--- a/mods/oni_mcp/Tools/WorldEditorVirtualFileReader.cs
+++ b/mods/oni_mcp/Tools/WorldEditorVirtualFileReader.cs
@@ -14,6 +14,8 @@ namespace OniMcp.Tools
 {
     public static partial class WorldEditorTools
     {
+        private const int VirtualMapLayerSize = 32;
+
         public static string ReadFileDirectly(string path)
         {
             bool isMd = path.EndsWith(".md", StringComparison.OrdinalIgnoreCase);
@@ -184,15 +186,29 @@ namespace OniMcp.Tools
                     string filename = Path.GetFileNameWithoutExtension(path);
                     string parts = filename.Substring("layer_".Length);
                     string[] split = parts.Split('_');
-                    if (split.Length == 2)
+                    if (split.Length == 2
+                        && int.TryParse(split[0], out int relYMin)
+                        && int.TryParse(split[1], out int relYMax))
                     {
-                        int relYMin = int.Parse(split[0]);
-                        int relYMax = int.Parse(split[1]);
-
                         int worldId = ClusterManager.Instance?.activeWorldId ?? 0;
                         var world = ClusterManager.Instance?.GetWorld(worldId);
                         if (world != null)
                         {
+                            int height = world.WorldSize.y;
+                            if (relYMin < 0
+                                || relYMax < relYMin
+                                || relYMax >= height
+                                || relYMin % VirtualMapLayerSize != 0)
+                            {
+                                return "<h1>Invalid map layer</h1><p>Requested map layer must match a listed 32-cell layer within the active world bounds.</p>";
+                            }
+
+                            int expectedRelYMax = Math.Min(relYMin + VirtualMapLayerSize - 1, height - 1);
+                            if (relYMax != expectedRelYMax)
+                            {
+                                return "<h1>Invalid map layer</h1><p>Requested map layer must match a listed 32-cell layer within the active world bounds.</p>";
+                            }
+
                             int xMin = world.WorldOffset.x;
                             int xMax = world.WorldOffset.x + world.WorldSize.x - 1;
                             int yMin = world.WorldOffset.y + relYMin;


### PR DESCRIPTION
### Motivation
- The virtual world browser accepted arbitrary `layer_*` filename ranges and dispatched unbounded per-cell HTML rendering on the Unity main thread, enabling unauthenticated denial-of-service via crafted GET requests; this change prevents oversized or malformed ranges from reaching the renderer.

### Description
- Add a `VirtualMapLayerSize` constant set to `32` to match the generated layer boundaries.
- Replace `int.Parse` with `int.TryParse` for `layer_<yMin>_<yMax>` filename parsing to reject non-integer or malformed names early.
- Validate that `relYMin >= 0`, `relYMax >= relYMin`, `relYMax < worldHeight`, `relYMin` is aligned to the 32-cell layer boundary, and `relYMax` matches the expected end for that layer, returning an error HTML page for invalid requests.
- These checks short-circuit before the expensive nested main-thread loops that build per-cell HTML, preventing large or out-of-bounds requests from consuming CPU/memory.

### Testing
- Ran `git diff --check` which completed successfully.
- Attempted `dotnet build mods/oni_mcp/OniMcp.csproj -c Debug --no-restore` but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a491ee51ae48320b500ca7fb1ca8147)

## Summary by Sourcery

在世界编辑器虚拟文件读取器中，对虚拟地图图层请求进行验证并加上边界限制，防止处理无效或超出范围的区间。

Bug 修复：
- 在解析图层请求时，拒绝格式错误或非整数的虚拟地图图层文件名。
- 在渲染之前，对虚拟地图图层范围强制施加世界高度及 32 单元格图层对齐约束，以避免越界和过度的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate and bound virtual map layer requests in the world editor virtual file reader to prevent invalid or oversized ranges from being processed.

Bug Fixes:
- Reject malformed or non-integer virtual map layer filenames when parsing layer requests.
- Enforce world-height and 32-cell layer alignment constraints on virtual map layer ranges before rendering to avoid out-of-bounds and excessive processing.

</details>