### PR TITLE
perf(cycletrim): optimize busy duplicant chore updates

### DIFF
--- a/mods/CycleTrim/CycleTrim.csproj
+++ b/mods/CycleTrim/CycleTrim.csproj
@@ -1,0 +1,83 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <AssemblyName>CycleTrim</AssemblyName>
+    <RootNamespace>CycleTrim</RootNamespace>
+    <LangVersion>7.3</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+
+    <ModTitle>CycleTrim</ModTitle>
+    <ModDescription>Reduces redundant smart reservoir signals, streamlines fetch pickup candidates, and refreshes expensive pickup and chore selection every other update only for busy duplicants, while idle duplicants and explicit priority updates remain immediate. / 减少智能储库重复信号、优化拾取候选选择，并仅对忙碌复制人隔次刷新高开销的拾取与差事重选；空闲和显式优先更新仍保持即时。</ModDescription>
+    <ModStaticID>LIghtJUNction.CycleTrim</ModStaticID>
+    <ModVersion>0.2.0</ModVersion>
+    <ModApiVersion>2</ModApiVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="0Harmony">
+      <HintPath>$(OniManagedPath)/0Harmony.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(OniManagedPath)/Assembly-CSharp.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>$(OniManagedPath)/Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>$(OniManagedPath)/UnityEngine.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(OniManagedPath)/UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PreviewImage Include="$(MSBuildProjectDirectory)/preview.png" Condition="Exists('$(MSBuildProjectDirectory)/preview.png')" />
+    <PreviewImage Include="$(MSBuildProjectDirectory)/preview.jpg" Condition="Exists('$(MSBuildProjectDirectory)/preview.jpg')" />
+  </ItemGroup>
+
+  <Target Name="GenerateModFiles" AfterTargets="Build">
+    <WriteLinesToFile File="$(OutputPath)mod.yaml" Lines="title: &quot;$(ModTitle)&quot;;description: &quot;$(ModDescription)&quot;;staticID: &quot;$(ModStaticID)&quot;" Overwrite="true" />
+    <WriteLinesToFile File="$(OutputPath)mod_info.yaml" Lines="supportedContent: ALL" Overwrite="true" />
+    <WriteLinesToFile File="$(OutputPath)mod_info.yaml" Lines="minimumSupportedBuild: 525812" Overwrite="false" />
+    <WriteLinesToFile File="$(OutputPath)mod_info.yaml" Lines="APIVersion: $(ModApiVersion)" Overwrite="false" />
+    <WriteLinesToFile File="$(OutputPath)mod_info.yaml" Lines="version: &quot;$(ModVersion)&quot;" Overwrite="false" />
+    <Copy SourceFiles="@(PreviewImage)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" Condition="'@(PreviewImage)' != ''" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)/README.md" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
+  </Target>
+
+  <Target Name="PackageMod" AfterTargets="GenerateModFiles">
+    <PropertyGroup>
+      <DistPath>$(MSBuildProjectDirectory)/../../dist/</DistPath>
+      <DistModPath>$(DistPath)$(AssemblyName)/</DistModPath>
+      <ZipFile>$(DistPath)$(AssemblyName).zip</ZipFile>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(DistPath)" />
+    <RemoveDir Directories="$(DistModPath)" />
+    <Delete Files="$(ZipFile)" />
+    <Delete Files="$(DistPath)$(AssemblyName)-src.tar.gz" />
+
+    <ItemGroup>
+      <ModOutputFiles Include="$(OutputPath)$(AssemblyName).dll" />
+      <ModOutputFiles Include="$(OutputPath)mod.yaml" />
+      <ModOutputFiles Include="$(OutputPath)mod_info.yaml" />
+      <ModOutputFiles Include="$(OutputPath)preview.png" Condition="Exists('$(OutputPath)preview.png')" />
+      <ModOutputFiles Include="$(OutputPath)preview.jpg" Condition="Exists('$(OutputPath)preview.jpg')" />
+      <ModOutputFiles Include="$(OutputPath)README.md" />
+    </ItemGroup>
+    <Copy SourceFiles="@(ModOutputFiles)" DestinationFolder="$(DistModPath)" />
+    <ZipDirectory SourceDirectory="$(DistModPath)" DestinationFile="$(ZipFile)" Overwrite="true" />
+    <Exec Command="tar -czf &quot;$(DistPath)$(AssemblyName)-src.tar.gz&quot; -C &quot;$(MSBuildProjectDirectory)&quot; --exclude=bin --exclude=obj --exclude=dist ." />
+
+    <Message Text="Packaged mod -&gt; $(ZipFile)" Importance="high" />
+    <Message Text="Packaged source -&gt; $(DistPath)$(AssemblyName)-src.tar.gz" Importance="high" />
+  </Target>
+
+</Project>

--- a/mods/CycleTrim/ModInfo.cs
+++ b/mods/CycleTrim/ModInfo.cs
@@ -1,0 +1,13 @@
+using HarmonyLib;
+
+namespace CycleTrim
+{
+    public sealed class ModInfo : KMod.UserMod2
+    {
+        public override void OnLoad(Harmony harmony)
+        {
+            base.OnLoad(harmony);
+            harmony.PatchAll();
+        }
+    }
+}

--- a/mods/CycleTrim/Patches/BusyDuplicantChoreThrottlePatch.cs
+++ b/mods/CycleTrim/Patches/BusyDuplicantChoreThrottlePatch.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+
+namespace CycleTrim.Patches
+{
+    internal static class BusyDuplicantChoreThrottlePatch
+    {
+        private const string FastTrackPatchType =
+            "PeterHan.FastTrack.GamePatches.FetchManagerFastUpdate";
+        private static readonly ConditionalWeakTable<ChoreConsumer, State> States =
+            new ConditionalWeakTable<ChoreConsumer, State>();
+        private static readonly ConditionalWeakTable<ChoreConsumer, State>.CreateValueCallback
+            StateFactory = CreateState;
+
+        private sealed class State
+        {
+            internal bool ForceRefresh;
+            internal bool SkipNextBusyUpdate;
+            internal bool SkipNextChoreSelection;
+        }
+
+        private static bool IsCompatible()
+        {
+            return AccessTools.TypeByName(FastTrackPatchType) == null;
+        }
+
+        private static State CreateState(ChoreConsumer consumer)
+        {
+            return new State();
+        }
+
+        private static bool TryGetDuplicantConsumer(
+            PickupableSensor sensor,
+            out ChoreConsumer consumer)
+        {
+            consumer = sensor.GetComponent<ChoreConsumer>();
+            return consumer != null && sensor.GetComponent<MinionIdentity>() != null;
+        }
+
+        [HarmonyPatch]
+        private static class PickupableSensorUpdatePatch
+        {
+            private static bool Prepare()
+            {
+                return IsCompatible();
+            }
+
+            private static MethodBase TargetMethod()
+            {
+                return AccessTools.Method(
+                        typeof(PickupableSensor),
+                        "Update",
+                        Type.EmptyTypes)
+                    ?? throw new InvalidOperationException(
+                        "CycleTrim could not find PickupableSensor.Update().");
+            }
+
+            private static bool Prefix(PickupableSensor __instance)
+            {
+                if (!TryGetDuplicantConsumer(__instance, out var consumer))
+                {
+                    return true;
+                }
+
+                var state = States.GetValue(consumer, StateFactory);
+                if (consumer.choreDriver.GetCurrentChore() == null)
+                {
+                    state.ForceRefresh = false;
+                    state.SkipNextBusyUpdate = false;
+                    state.SkipNextChoreSelection = false;
+                    return true;
+                }
+
+                if (state.ForceRefresh)
+                {
+                    state.ForceRefresh = false;
+                    state.SkipNextBusyUpdate = true;
+                    state.SkipNextChoreSelection = false;
+                    return true;
+                }
+
+                if (!state.SkipNextBusyUpdate)
+                {
+                    state.SkipNextBusyUpdate = true;
+                    state.SkipNextChoreSelection = false;
+                    return true;
+                }
+
+                state.SkipNextBusyUpdate = false;
+                state.SkipNextChoreSelection = true;
+                return false;
+            }
+        }
+
+        [HarmonyPatch]
+        private static class FindNextChorePatch
+        {
+            private static bool Prepare()
+            {
+                return IsCompatible();
+            }
+
+            private static MethodBase TargetMethod()
+            {
+                return AccessTools.Method(
+                        typeof(ChoreConsumer),
+                        "FindNextChore",
+                        new[] { typeof(Chore.Precondition.Context).MakeByRefType() })
+                    ?? throw new InvalidOperationException(
+                        "CycleTrim could not find ChoreConsumer.FindNextChore(ref Context).");
+            }
+
+            private static bool Prefix(
+                ChoreConsumer __instance,
+                ref Chore.Precondition.Context out_context,
+                ref bool __result)
+            {
+                if (!States.TryGetValue(__instance, out var state))
+                {
+                    return true;
+                }
+
+                var skipSelection = state.SkipNextChoreSelection;
+                state.SkipNextChoreSelection = false;
+                if (!skipSelection || __instance.choreDriver.GetCurrentChore() == null)
+                {
+                    return true;
+                }
+
+                out_context = default(Chore.Precondition.Context);
+                __result = false;
+                return false;
+            }
+        }
+
+        [HarmonyPatch]
+        private static class PrioritizeBrainPatch
+        {
+            private static bool Prepare()
+            {
+                return IsCompatible();
+            }
+
+            private static MethodBase TargetMethod()
+            {
+                return AccessTools.Method(
+                        typeof(BrainScheduler),
+                        "PrioritizeBrain",
+                        new[] { typeof(Brain) })
+                    ?? throw new InvalidOperationException(
+                        "CycleTrim could not find BrainScheduler.PrioritizeBrain(Brain).");
+            }
+
+            private static void Prefix(Brain brain)
+            {
+                if (brain == null || brain.GetComponent<MinionIdentity>() == null)
+                {
+                    return;
+                }
+
+                var consumer = brain.GetComponent<ChoreConsumer>();
+                if (consumer != null)
+                {
+                    States.GetValue(consumer, StateFactory).ForceRefresh = true;
+                }
+            }
+        }
+    }
+}

--- a/mods/CycleTrim/Patches/FetchPickupCandidatePatch.cs
+++ b/mods/CycleTrim/Patches/FetchPickupCandidatePatch.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+
+namespace CycleTrim.Patches
+{
+    internal static class FetchPickupCandidatePatch
+    {
+        private const string FastTrackPatchType =
+            "PeterHan.FastTrack.GamePatches.FetchManagerFastUpdate";
+        private static readonly ConcurrentStack<Dictionary<PickupKey, FetchManager.Pickup>>
+            CandidatePool =
+                new ConcurrentStack<Dictionary<PickupKey, FetchManager.Pickup>>();
+        private static readonly Comparison<FetchManager.Pickup> FinalPickupOrder =
+            CompareIncludingPriority;
+
+        private readonly struct PickupKey : IEquatable<PickupKey>
+        {
+            private readonly int tagBitsHash;
+            private readonly int masterPriority;
+
+            internal PickupKey(int tagBitsHash, int masterPriority)
+            {
+                this.tagBitsHash = tagBitsHash;
+                this.masterPriority = masterPriority;
+            }
+
+            public bool Equals(PickupKey other)
+            {
+                return tagBitsHash == other.tagBitsHash
+                    && masterPriority == other.masterPriority;
+            }
+
+            public override bool Equals(object value)
+            {
+                return value is PickupKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (tagBitsHash * 397) ^ masterPriority;
+                }
+            }
+        }
+
+        [HarmonyPatch]
+        private static class UpdatePickupsPatch
+        {
+            // Inspired by Peter Han's FastTrack (MIT), with a smaller vanilla-equivalent design.
+            private static bool Prepare()
+            {
+                return AccessTools.TypeByName(FastTrackPatchType) == null;
+            }
+
+            private static MethodBase TargetMethod()
+            {
+                return AccessTools.Method(
+                        typeof(FetchManager.FetchablesByPrefabId),
+                        "UpdatePickups",
+                        new[] { typeof(Navigator), typeof(int) })
+                    ?? throw new InvalidOperationException(
+                        "CycleTrim could not find FetchablesByPrefabId.UpdatePickups(Navigator, int).");
+            }
+
+            private static bool Prefix(
+                FetchManager.FetchablesByPrefabId __instance,
+                Navigator worker_navigator,
+                int worker,
+                Dictionary<int, int> ___cellCosts)
+            {
+                if (!CandidatePool.TryPop(out var candidates))
+                {
+                    candidates = new Dictionary<PickupKey, FetchManager.Pickup>();
+                }
+
+                try
+                {
+                    ___cellCosts.Clear();
+                    __instance.finalPickups.Clear();
+                    foreach (var fetchable in __instance.fetchables.GetDataList())
+                    {
+                        var pickupable = fetchable.pickupable;
+                        if (!pickupable.CouldBePickedUpByMinion(worker))
+                        {
+                            continue;
+                        }
+
+                        var cell = pickupable.cachedCell;
+                        if (!___cellCosts.TryGetValue(cell, out var pathCost))
+                        {
+                            pathCost = pickupable.GetNavigationCost(worker_navigator, cell);
+                            ___cellCosts[cell] = pathCost;
+                        }
+
+                        if (pathCost == -1)
+                        {
+                            continue;
+                        }
+
+                        var pickup = new FetchManager.Pickup
+                        {
+                            pickupable = pickupable,
+                            tagBitsHash = fetchable.tagBitsHash,
+                            PathCost = (ushort)pathCost,
+                            masterPriority = fetchable.masterPriority,
+                            freshness = fetchable.freshness,
+                            foodQuality = fetchable.foodQuality
+                        };
+                        var key = new PickupKey(pickup.tagBitsHash, pickup.masterPriority);
+                        if (!candidates.TryGetValue(key, out var current)
+                            || IsBetter(pickup, current))
+                        {
+                            candidates[key] = pickup;
+                        }
+                    }
+
+                    foreach (var candidate in candidates.Values)
+                    {
+                        __instance.finalPickups.Add(candidate);
+                    }
+
+                    __instance.finalPickups.Sort(FinalPickupOrder);
+                    return false;
+                }
+                finally
+                {
+                    candidates.Clear();
+                    CandidatePool.Push(candidates);
+                }
+            }
+
+            private static bool IsBetter(
+                FetchManager.Pickup candidate,
+                FetchManager.Pickup current)
+            {
+                if (candidate.PathCost != current.PathCost)
+                {
+                    return candidate.PathCost < current.PathCost;
+                }
+
+                if (candidate.foodQuality != current.foodQuality)
+                {
+                    return candidate.foodQuality > current.foodQuality;
+                }
+
+                return candidate.freshness > current.freshness;
+            }
+        }
+
+        private static int CompareIncludingPriority(
+            FetchManager.Pickup left,
+            FetchManager.Pickup right)
+        {
+            var order = left.tagBitsHash.CompareTo(right.tagBitsHash);
+            if (order != 0)
+            {
+                return order;
+            }
+
+            order = right.masterPriority.CompareTo(left.masterPriority);
+            if (order != 0)
+            {
+                return order;
+            }
+
+            order = left.PathCost.CompareTo(right.PathCost);
+            if (order != 0)
+            {
+                return order;
+            }
+
+            order = right.foodQuality.CompareTo(left.foodQuality);
+            return order != 0 ? order : right.freshness.CompareTo(left.freshness);
+        }
+    }
+}

--- a/mods/CycleTrim/Patches/SmartReservoirSignalPatch.cs
+++ b/mods/CycleTrim/Patches/SmartReservoirSignalPatch.cs
@@ -17,6 +17,11 @@ namespace CycleTrim.Patches
 
             private static void Postfix(bool ___activated, LogicPorts ___logicPorts)
             {
+                if (___logicPorts == null)
+                {
+                    return;
+                }
+
                 ___logicPorts.SendSignal(SmartReservoir.PORT_ID, ___activated ? 1 : 0);
             }
         }

--- a/mods/CycleTrim/Patches/SmartReservoirSignalPatch.cs
+++ b/mods/CycleTrim/Patches/SmartReservoirSignalPatch.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+
+namespace CycleTrim.Patches
+{
+    internal static class SmartReservoirSignalPatch
+    {
+        [HarmonyPatch]
+        private static class OnSpawnPatch
+        {
+            private static MethodBase TargetMethod()
+            {
+                return AccessTools.Method(typeof(SmartReservoir), "OnSpawn")
+                    ?? throw new InvalidOperationException("CycleTrim could not find SmartReservoir.OnSpawn.");
+            }
+
+            private static void Postfix(bool ___activated, LogicPorts ___logicPorts)
+            {
+                ___logicPorts.SendSignal(SmartReservoir.PORT_ID, ___activated ? 1 : 0);
+            }
+        }
+
+        [HarmonyPatch]
+        private static class UpdateLogicCircuitPatch
+        {
+            private static MethodBase TargetMethod()
+            {
+                return AccessTools.Method(
+                        typeof(SmartReservoir),
+                        "UpdateLogicCircuit",
+                        new[] { typeof(object) })
+                    ?? throw new InvalidOperationException(
+                        "CycleTrim could not find SmartReservoir.UpdateLogicCircuit(object).");
+            }
+
+            private static bool Prefix(
+                SmartReservoir __instance,
+                ref bool ___activated,
+                int ___activateValue,
+                int ___deactivateValue,
+                LogicPorts ___logicPorts)
+            {
+                var percent = __instance.PercentFull * 100f;
+                var wasActivated = ___activated;
+                if (wasActivated)
+                {
+                    if (percent >= ___deactivateValue)
+                    {
+                        ___activated = false;
+                    }
+                }
+                else if (percent <= ___activateValue)
+                {
+                    ___activated = true;
+                }
+
+                if (___activated != wasActivated)
+                {
+                    ___logicPorts.SendSignal(
+                        SmartReservoir.PORT_ID,
+                        ___activated ? 1 : 0);
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/mods/CycleTrim/README.md
+++ b/mods/CycleTrim/README.md
@@ -1,0 +1,47 @@
+# CycleTrim 0.2.0
+
+CycleTrim is a narrowly scoped performance mod for Oxygen Not Included.
+
+CycleTrim 是一个针对《缺氧》具体热路径的性能优化 Mod。
+
+## Production optimizations / 生产优化
+
+1. Smart reservoirs send their automation output on spawn and then only when the output changes.  
+   智能液库与气库在生成时初始化自动化输出，之后仅在输出变化时发送信号。
+2. Fetch pickup candidates reuse cached cell costs and retain the best vanilla-ranked candidate for each tag and priority group. Vanilla eligibility and final ranking are preserved.  
+   拾取候选选择复用格子路径代价，并为每个标签与优先级组保留原版排序下的最佳候选；原版资格与最终排序保持不变。
+3. Only busy duplicants alternate expensive pickup refresh and chore reselection. Idle duplicants always refresh immediately, and `BrainScheduler.PrioritizeBrain` forces the next refresh to run immediately. Critters are not affected.  
+   仅忙碌复制人会隔次执行高开销的拾取刷新与差事重选。空闲复制人始终立即刷新，`BrainScheduler.PrioritizeBrain` 也会强制下一次立即刷新。小动物不受影响。
+
+If `PeterHan.FastTrack.GamePatches.FetchManagerFastUpdate` is detected, CycleTrim disables the overlapping fetch and busy-duplicant patches.
+
+如果检测到 `PeterHan.FastTrack.GamePatches.FetchManagerFastUpdate`，CycleTrim 会禁用重叠的拾取与忙碌复制人补丁。
+
+## Fixed-scenario validation / 固定场景验证
+
+Test scene: A01, cycle 1641, 15 duplicants, world 0, game window 665x508, camera view X35-55/Y71-91, speed 3x, using paired 30-second windows.
+
+测试场景：A01，第 1641 周期，15 名复制人，world 0，游戏窗口 665x508，镜头 X35-55/Y71-91，3x 速度，使用成对的 30 秒窗口。
+
+The baseline used the same Debug build with only the new busy-duplicant throttle disabled; the two existing 0.1.9 optimizations remained enabled. The candidate enabled the throttle.
+
+基线使用同一 Debug 构建，仅关闭新的忙碌复制人节流；0.1.9 已有的两项优化仍然开启。候选组开启该节流。
+
+- Paired FPS: `74.9 -> 84.5` (+12.9%), `78.8 -> 89.5` (+13.6%), `70.6 -> 85.1` (+20.6%); median +13.6%.
+- Warm-window hot paths: Brain `5.087s -> 2.449s` (-51.9%), PickupableSensor `2.147s -> 0.104s` (-95.1%), FindNextChore `1.434s -> 0.523s` (-63.5%).
+
+这些是该固定存档、硬件和镜头下的增量结果，不是 vanilla-vs-mod 对比，也不保证所有殖民地都获得相同 FPS。
+
+These are incremental results for this fixed save, hardware, and camera view. They are not a vanilla-vs-mod comparison and do not guarantee the same FPS on every colony.
+
+## Compatibility and build / 兼容与构建
+
+- Supports base game and DLC content through `supportedContent: ALL`.
+- Runtime contract checks are in `scripts/verify_cycletrim_target_contract.py`.
+- 通过 `supportedContent: ALL` 支持基础游戏与 DLC 内容。
+- 运行时契约检查位于 `scripts/verify_cycletrim_target_contract.py`。
+
+```bash
+onim build -m CycleTrim
+onim dev -m CycleTrim
+```

--- a/mods/CycleTrim/preview.png
+++ b/mods/CycleTrim/preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b3e8563736c726b90fa94b9a654ffe7bd3b189709b0b7a9ed548f427ee4d1bb
+size 363944

--- a/onim.toml
+++ b/onim.toml
@@ -8,3 +8,5 @@ default_mod = "oni_mcp"
 path = "mods/oni_mcp"
 # Steam 创意工坊 ID，首次上传后填写，后续发布时自动使用
 publishedfileid = "3731864673"
+[mods.CycleTrim]
+path = "mods/CycleTrim"

--- a/scripts/verify_cycletrim_target_contract.py
+++ b/scripts/verify_cycletrim_target_contract.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Verify the live ONI APIs assumed by CycleTrim."""
+
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+DEFAULT_ASSEMBLY = (
+    Path.home()
+    / ".local/share/Steam/steamapps/common/OxygenNotIncluded/"
+    "OxygenNotIncluded_Data/Managed/Assembly-CSharp.dll"
+)
+
+
+def decompile(assembly: Path, type_name: str) -> str:
+    result = subprocess.run(
+        ["ilspycmd", "-t", type_name, str(assembly)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def method_body(source: str, signature: str) -> str:
+    start = source.find(signature)
+    if start < 0:
+        raise ValueError(f"missing method: {signature}")
+    opening = source.find("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    raise ValueError(f"unterminated method: {signature}")
+
+
+def main() -> int:
+    assembly = Path(sys.argv[1]).expanduser() if len(sys.argv) > 1 else DEFAULT_ASSEMBLY
+    if len(sys.argv) > 2:
+        print("FAIL: usage: verify_cycletrim_target_contract.py [Assembly-CSharp.dll]", file=sys.stderr)
+        return 2
+    if not assembly.is_file():
+        print(f"FAIL: assembly not found: {assembly}", file=sys.stderr)
+        return 1
+
+    try:
+        source = decompile(assembly, "SmartReservoir")
+        sim_body = method_body(source, "public void Sim200ms(float dt)")
+        update_body = method_body(source, "private void UpdateLogicCircuit(object data)")
+        failures = []
+        if not re.search(r"\bUpdateLogicCircuit\s*\(\s*null\s*\)\s*;", sim_body):
+            failures.append("Sim200ms no longer calls UpdateLogicCircuit(null)")
+        signal_calls = len(re.findall(r"\blogicPorts\.SendSignal\s*\(", update_body))
+        if signal_calls != 1:
+            failures.append(
+                f"UpdateLogicCircuit has {signal_calls} LogicPorts.SendSignal calls; expected 1"
+            )
+        if not re.search(r"\bprivate\s+bool\s+activated\s*;", source):
+            failures.append("SmartReservoir.activated bool field is missing")
+        if not re.search(r"\bprivate\s+LogicPorts\s+logicPorts\s*;", source):
+            failures.append("SmartReservoir.logicPorts LogicPorts field is missing")
+        if not re.search(
+            r"\bprotected\s+override\s+void\s+OnSpawn\s*\(\s*\)", source
+        ):
+            failures.append("SmartReservoir no longer declares protected override void OnSpawn()")
+        for field in ("activateValue", "deactivateValue"):
+            if not re.search(rf"\bprivate\s+int\s+{field}\b", source):
+                failures.append(f"SmartReservoir.{field} int field is missing")
+        if not re.search(
+            r"if\s*\(\s*activated\s*\)\s*\{\s*if\s*\(\s*num\s*>=\s*"
+            r"\(float\)deactivateValue\s*\)",
+            update_body,
+        ):
+            failures.append("activated branch no longer deactivates at percent >= deactivateValue")
+        if not re.search(
+            r"else\s+if\s*\(\s*num\s*<=\s*\(float\)activateValue\s*\)",
+            update_body,
+        ):
+            failures.append("inactive branch no longer activates at percent <= activateValue")
+        if failures:
+            for failure in failures:
+                print(f"FAIL: {failure}", file=sys.stderr)
+            return 1
+
+        fetch_source = decompile(assembly, "FetchManager")
+        fetch_failures = []
+        inner_signature = "public void UpdatePickups(Navigator worker_navigator, int worker)"
+        if fetch_source.count(inner_signature) != 1:
+            fetch_failures.append("exact FetchablesByPrefabId.UpdatePickups(Navigator, int) overload drifted")
+        for pattern, message in (
+            (r"public\s+KCompactedVector<Fetchable>\s+fetchables\s*;", "fetchables field drifted"),
+            (r"public\s+List<Pickup>\s+finalPickups\b", "finalPickups field drifted"),
+            (r"private\s+Dictionary<int,\s*int>\s+cellCosts\b", "cellCosts field drifted"),
+            (r"pickupable\.CouldBePickedUpByMinion\s*\(\s*worker\s*\)", "worker eligibility check drifted"),
+            (r"cellCosts\.TryGetValue\s*\(\s*pickupable\.cachedCell", "cached-cell cost lookup drifted"),
+            (r"pickupable\.GetNavigationCost\s*\(\s*navigator\s*,\s*pickupable\.cachedCell\s*\)", "cached-cell navigation call drifted"),
+        ):
+            if not re.search(pattern, fetch_source):
+                fetch_failures.append(message)
+        outer_body = method_body(
+            fetch_source,
+            "public void UpdatePickups(Navigator navigator, WorkerBase worker)",
+        )
+        if not re.search(
+            r"pickups\.Sort\s*\(\s*PickupComparerNoPriority\.CompareInst\s*\)",
+            outer_body,
+        ):
+            fetch_failures.append("outer PickupComparerNoPriority final sort drifted")
+        if fetch_failures:
+            for failure in fetch_failures:
+                print(f"FAIL: {failure}", file=sys.stderr)
+            return 1
+
+        chore_failures = []
+        sensor_source = decompile(assembly, "PickupableSensor")
+        sensor_body = method_body(sensor_source, "public override void Update()")
+        sensor_calls = (
+            r"GlobalChoreProvider\.Instance\.UpdateFetches\s*\(\s*navigator\s*\)",
+            r"Game\.Instance\.fetchManager\.UpdatePickups\s*\(\s*navigator\s*,\s*worker\s*\)",
+        )
+        if any(len(re.findall(call, sensor_body)) != 1 for call in sensor_calls):
+            chore_failures.append("PickupableSensor.Update no longer has its two expected calls")
+
+        consumer_source = decompile(assembly, "ChoreConsumer")
+        consumer_signature = (
+            "public bool FindNextChore(ref Chore.Precondition.Context out_context)"
+        )
+        if consumer_source.count(consumer_signature) != 1:
+            chore_failures.append("ChoreConsumer.FindNextChore(ref Context) signature drifted")
+        if not re.search(r"public\s+ChoreDriver\s+choreDriver\s*;", consumer_source):
+            chore_failures.append("ChoreConsumer.choreDriver structure drifted")
+        if not re.search(r"choreDriver\.GetCurrentChore\s*\(\s*\)", consumer_source):
+            chore_failures.append("ChoreConsumer current chore access drifted")
+
+        scheduler_source = decompile(assembly, "BrainScheduler")
+        prioritize_matches = re.findall(
+            r"public\s+void\s+PrioritizeBrain\s*\(\s*Brain\s+brain\s*\)",
+            scheduler_source,
+        )
+        if len(prioritize_matches) < 1:
+            chore_failures.append("BrainScheduler.PrioritizeBrain(Brain) is missing")
+
+        if chore_failures:
+            for failure in chore_failures:
+                print(f"FAIL: {failure}", file=sys.stderr)
+            return 1
+    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    print(f"PASS: CycleTrim target contracts match ({assembly})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add CycleTrim 0.2.0 performance optimization mod
- throttle busy duplicant chore refreshes while preserving immediate idle/prioritized updates
- document measured A/B benchmark results and compatibility boundaries

## Validation
- target contract verifier passed
- Debug and Release builds completed with 0 warnings and 0 errors
- release package and installed development build were verified

## Summary by Sourcery

引入 CycleTrim 0.2.0 性能模组，并将其接入 ONI 模组加载器。

新特性：
- 添加 CycleTrim 模组入口和项目骨架，包括基于 Harmony 的初始化。
- 优化搬运候选对象的选择逻辑，复用导航成本，并在保持原版候选资格与排序规则的前提下，为每个标签/优先级分组仅保留一个最佳候选。
- 限制忙碌复制人（duplicant）在物品拾取刷新和任务重选上的频率，同时保持空闲/高优先级更新的灵敏响应，并排除动物（critters）。
- 优化 SmartReservoir（智能储液罐）的自动化信号逻辑，使其在生成时初始化，并且仅在激活状态变化时发出逻辑信号。

增强：
- 添加基于 Python 的目标契约验证脚本，用于在 SmartReservoir、FetchManager、PickupableSensor、ChoreConsumer 和 BrainScheduler 等组件之间，防范 ONI API 漂移对 CycleTrim 的影响。
- 在专门的 README 中记录 CycleTrim 0.2.0 的行为说明、性能基准、兼容性边界以及构建/开发命令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce the CycleTrim 0.2.0 performance mod and wire it into the ONI mod loader.

New Features:
- Add the CycleTrim mod entry and project skeleton, including Harmony-driven initialization.
- Optimize fetch pickup candidate selection to reuse navigation costs and retain a single best candidate per tag/priority group while preserving vanilla eligibility and ordering.
- Throttle busy duplicant pickup refreshes and chore reselection while keeping idle/prioritized updates responsive and excluding critters.
- Refine SmartReservoir automation signaling to initialize on spawn and only emit logic signals when the activation state changes.

Enhancements:
- Add a Python-based target contract verifier script to guard CycleTrim against ONI API drift across SmartReservoir, FetchManager, PickupableSensor, ChoreConsumer, and BrainScheduler.
- Document CycleTrim 0.2.0 behavior, performance benchmarks, compatibility boundaries, and build/dev commands in a dedicated README.

</details>