### PR TITLE
fix(oni-mcp): preserve auth during config migration

### DIFF
--- a/mods/OniMcp/Config/OniMcpOptions.cs
+++ b/mods/OniMcp/Config/OniMcpOptions.cs
@@ -267,7 +267,7 @@ namespace OniMcp.Config
             int version = raw["SecurityMigrationVersion"]?.Value<int>() ?? 0;
             if (version >= CurrentSecurityMigrationVersion)
                 return;
-            options.AuthEnabled = false;
+            // Preserve the user's opt-in authentication choice during migration.
             options.SecurityMigrationVersion = CurrentSecurityMigrationVersion;
         }
 

--- a/mods/OniMcp/README.md
+++ b/mods/OniMcp/README.md
@@ -46,7 +46,8 @@ ONI MCP Server 是《缺氧》Mod：启动本地 MCP 服务（`http://localhost:
 
 - 配置文件: `OniMcpConfig.json`
 - 常见字段、默认值与优先路径见: [mods/OniMcp/ModInfo.cs](ModInfo.cs)
-- 默认 `AuthEnabled` 为 `false`；如需局域网访问建议开启认证并设置强随机 token。
+- 默认 `AuthEnabled` 为 `false`；仅手动开启认证后才会强制 token，如需局域网访问建议开启认证并设置强随机 token。
+- 安全迁移只记录迁移版本，不会改变既有 `AuthEnabled` 选择；已开启认证的旧配置仍要求客户端携带 token。
 - 修改配置后点击 **Restart MCP server** 或重启游戏生效。
 
 ## 主要工具组

--- a/mods/OniMcp/README_EN.md
+++ b/mods/OniMcp/README_EN.md
@@ -46,7 +46,8 @@ ONI MCP Server is an Oxygen Not Included mod that exposes a local MCP service (`
 
 - Config file: `OniMcpConfig.json`
 - Default fields and load precedence are in: [mods/OniMcp/ModInfo.cs](ModInfo.cs)
-- Default `AuthEnabled` is `false`; enable auth if exposing beyond local host.
+- Default `AuthEnabled` is `false`; token enforcement applies only after authentication is manually enabled, and auth should be enabled if exposing beyond local host.
+- Security migration records its version without changing an existing `AuthEnabled` choice; legacy configurations with auth enabled continue to require a token from clients.
 - Restart MCP server via options button or full game restart after config updates.
 
 ## Tool Groups

--- a/scripts/verify_auth_options_contract.py
+++ b/scripts/verify_auth_options_contract.py
@@ -39,7 +39,8 @@ def main() -> int:
     assert "CurrentSecurityMigrationVersion = 1" in options
     migration = method_body(options, "private static void ApplySecurityMigration")
     assert 'raw["SecurityMigrationVersion"]' in migration
-    assert "options.AuthEnabled = false" in migration
+    assignments = re.findall(r"options\.(\w+)\s*=", migration)
+    assert assignments == ["SecurityMigrationVersion"], assignments
     assert "options.SecurityMigrationVersion = CurrentSecurityMigrationVersion" in migration
     assert "ApplySecurityMigration(loaded, raw)" in options
 


### PR DESCRIPTION
### Motivation
- Prevent an automatic downgrade of existing MCP installations by ensuring the security migration does not unconditionally disable `AuthEnabled` for configs that predate `SecurityMigrationVersion`.

### Description
- Remove the unconditional `options.AuthEnabled = false;` assignment from `ApplySecurityMigration` in `mods/oni_mcp/Config/OniMcpOptions.cs` and update `scripts/verify_auth_options_contract.py` to assert that the migration does not disable authentication.

### Testing
- Ran `uv run scripts/verify_auth_options_contract.py`, which passed. 
- Ran `git diff --check`, which produced no issues. 
- Attempted `dotnet build mods/oni_mcp/OniMcp.csproj -c Debug` but the `dotnet` tool was not available in the container, so a full project build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59f46e7f588320b414ea5a6af0d8a0)

## 由 Sourcery 生成的摘要

通过移除无条件禁用认证的逻辑，并收紧验证脚本来确保迁移不再关闭认证，从而在对 Oni MCP 进行安全配置迁移时保留现有的认证设置。

错误修复：
- 修复在对 Oni MCP 选项应用安全迁移时意外禁用认证的问题。

测试：
- 更新认证选项验证脚本，以断言安全迁移不会禁用认证。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve existing authentication settings during security config migration for Oni MCP by removing the unconditional auth disabling and tightening the verification script to ensure migrations no longer turn off authentication.

Bug Fixes:
- Fix unintended disabling of authentication when applying the security migration to Oni MCP options.

Tests:
- Update the auth options verification script to assert that security migration does not disable authentication.

</details>