### PR TITLE
docs: connect OniMods with LMM developer infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A large-scale modular repository for Oxygen Not Included mod development:
 
 > **Compatibility warning**: before `1.0.0`, the `OniMcp` API can still introduce breaking changes. If you build derivatives, plugins, scripts, or third-party clients, pin exact versions and use runtime manifests (e.g. `oni://tools/manifest`) as the compatibility source of truth.
 
-> **Open-Source Incentive Program**: Buy tokens or earn tokens by contributing to open-source projects. Visit [api.lmm.best](https://api.lmm.best). The source code is open, and contributions are welcome.
+> **AI infrastructure & open-source support:** OniMcp development and agent testing consume model API credits. If you need an OpenAI-compatible endpoint for your MCP client, [LMM API Gateway](https://api.lmm.best) is one available option. LMM is maintained by the OniMods author; purchases help fund this work, while substantive issues, pull requests, and testing may receive API credits. OniMods remains open source and does not require this provider.
 
 ## Table of Contents
 


### PR DESCRIPTION
## What changed

- Reframed the existing LMM mention around AI infrastructure and open-source support.
- Clarified that LMM is an optional OpenAI-compatible endpoint for MCP clients.
- Explained how purchases and substantive community contributions help sustain OniMods.

## Why

This presents a credible open-source funding loop without implying that OniMods requires one API provider.

## Validation

- README-only change
- Compared the branch against `main`: 1 line added, 1 line removed
- Verified the rendered Markdown link and surrounding README structure

## Summary by Sourcery

Documentation:
- 修改 README 中的开源激励部分，将 LMM 描述为可选的 AI 基础设施端点，并说明使用和贡献如何帮助维持 OniMods 的可持续发展。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Revise the README open-source incentive section to describe LMM as an optional AI infrastructure endpoint and explain how usage and contributions help sustain OniMods.

</details>
- 修订 README 中描述 LMM 的部分，强调其作为可选的、兼容 OpenAI 的端点的角色，以及购买和贡献如何支持 OniMods。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- 修改 README 中的开源激励部分，将 LMM 描述为可选的 AI 基础设施端点，并说明使用和贡献如何帮助维持 OniMods 的可持续发展。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Revise the README open-source incentive section to describe LMM as an optional AI infrastructure endpoint and explain how usage and contributions help sustain OniMods.

</details>

</details>