### PR TITLE
fix(mods): harden OniMcp and CycleTrim with executable regressions

### DIFF
--- a/.github/workflows/mod-quality.yml
+++ b/.github/workflows/mod-quality.yml
@@ -1,0 +1,40 @@
+name: Mod quality
+
+on:
+  pull_request:
+    paths:
+      - 'mods/**'
+      - 'tests/**'
+      - 'benchmarks/CycleTrim.BrainBenchmarks/**'
+      - 'scripts/**'
+      - '.github/workflows/mod-quality.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'mods/**'
+      - 'tests/**'
+      - 'benchmarks/CycleTrim.BrainBenchmarks/**'
+      - 'scripts/**'
+      - '.github/workflows/mod-quality.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mod-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: Check Mod source contracts and behavior
+        run: python3 scripts/check_mods.py

--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ cp Directory.Build.props.example Directory.Build.props
 3. Add/update docs/changelog links when behavior changes
 4. Confirm local workflow (`onim setup`, relevant verify scripts) before merging
 
+Run `python3 scripts/check_mods.py` with Python 3 and .NET SDK 10 for the Mod
+regression suite. See [Mod testing](docs/mod-testing.md) for coverage and the
+additional checks that require an installed game.
+
 ## Dependencies
 
 - [Rust](https://rustup.rs/) to compile `onim`

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -174,6 +174,10 @@ cp Directory.Build.props.example Directory.Build.props
 
 ## 依赖
 
+代码回归检查：安装 Python 3 与 .NET SDK 10 后运行
+`python3 scripts/check_mods.py`。该入口不需要安装游戏；完整构建与游戏内验证步骤见
+[Mod 测试说明](docs/mod-testing.md)。
+
 - [Rust](https://rustup.rs/)：编译 `onim`
 - [.NET SDK](https://dotnet.microsoft.com/download)：构建 Mod
 - `unzip`：安装构建产物时解压

--- a/benchmarks/CycleTrim.BrainBenchmarks/PathProbeRegressionTests.cs
+++ b/benchmarks/CycleTrim.BrainBenchmarks/PathProbeRegressionTests.cs
@@ -1,0 +1,138 @@
+using CycleTrim.Core;
+
+namespace CycleTrim.BrainBenchmarks
+{
+    internal static partial class Program
+    {
+        private static void RunPathProbeRegressionTests()
+        {
+            RunTest(
+                nameof(DiscardedFallbackCannotReusePreviousCompletion),
+                DiscardedFallbackCannotReusePreviousCompletion);
+            RunTest(
+                nameof(UnsupportedProbeInvalidatesQueuedInFlightAndCompletedState),
+                UnsupportedProbeInvalidatesQueuedInFlightAndCompletedState);
+            RunTest(
+                nameof(UntrackedDequeueCannotCompletePreviousProbe),
+                UntrackedDequeueCannotCompletePreviousProbe);
+            RunTest(
+                nameof(RejectedReplacementCannotReusePreviousCompletion),
+                RejectedReplacementCannotReusePreviousCompletion);
+            RunTest(
+                nameof(QueuedProbeUsesTheFinalWorkOrderSnapshot),
+                QueuedProbeUsesTheFinalWorkOrderSnapshot);
+            RunTest(
+                nameof(PathProbeBackpressureHandlesMaximumCounters),
+                PathProbeBackpressureHandlesMaximumCounters);
+        }
+
+        private static void DiscardedFallbackCannotReusePreviousCompletion()
+        {
+            var state = new PathProbeAdmissionState(1);
+            var stamp = CreateRegressionStamp(1);
+            CompleteProbe(state, stamp);
+            AssertFalse(state.TryAdmit(stamp, true), "first stable request hits");
+            AssertTrue(state.TryAdmit(stamp, true), "bounded fallback enters queue");
+
+            state.BeginTick();
+            AssertTrue(state.TryAdmit(stamp, true), "discarded fallback must retry immediately");
+            state.MarkDequeued();
+            state.MarkApplied();
+            AssertFalse(state.TryAdmit(stamp, true), "applied retry enables cache again");
+        }
+
+        private static void UnsupportedProbeInvalidatesQueuedInFlightAndCompletedState()
+        {
+            var stamp = CreateRegressionStamp(1);
+            for (var phase = 0; phase < 3; phase++)
+            {
+                var state = new PathProbeAdmissionState(8);
+                AssertTrue(state.TryAdmit(stamp, true), "tracked probe enters queue");
+                if (phase >= 1)
+                {
+                    state.MarkDequeued();
+                }
+                if (phase >= 2)
+                {
+                    state.MarkApplied();
+                }
+
+                AssertTrue(state.TryAdmit(stamp, false), "unsupported probe stays vanilla");
+                state.MarkDequeued();
+                state.MarkApplied();
+                AssertTrue(
+                    state.TryAdmit(stamp, true),
+                    "unsupported completion cannot restore tracked phase " + phase);
+            }
+        }
+
+        private static void UntrackedDequeueCannotCompletePreviousProbe()
+        {
+            var state = new PathProbeAdmissionState(8);
+            var stamp = CreateRegressionStamp(1);
+            AssertTrue(state.TryAdmit(stamp, true), "first probe admitted");
+            state.MarkDequeued();
+
+            // An untracked order can be dequeued after the earlier result was
+            // dropped. Its TakeResult must not complete the earlier stamp.
+            state.BeginTick();
+            state.MarkDequeued();
+            state.MarkApplied();
+            AssertTrue(state.TryAdmit(stamp, true), "untracked result never creates a hit");
+        }
+
+        private static void RejectedReplacementCannotReusePreviousCompletion()
+        {
+            var state = new PathProbeAdmissionState(8);
+            var original = CreateRegressionStamp(1);
+            var replacement = CreateRegressionStamp(2);
+            CompleteProbe(state, original);
+            AssertTrue(state.TryAdmit(replacement, true), "changed context requires probe");
+            state.MarkDequeued();
+            state.RejectInFlight();
+            state.MarkApplied();
+            AssertTrue(state.TryAdmit(original, true), "rejected replacement requires fresh result");
+        }
+
+        private static void QueuedProbeUsesTheFinalWorkOrderSnapshot()
+        {
+            var state = new PathProbeAdmissionState(8);
+            var captured = CreateRegressionStamp(1);
+            var queued = CreateRegressionStamp(2);
+            AssertTrue(state.TryAdmit(captured, true), "initial snapshot admitted");
+            state.ReplaceQueuedStamp(queued);
+            state.MarkDequeued();
+            state.MarkApplied();
+            AssertFalse(state.TryAdmit(queued, true), "work order snapshot was completed");
+            AssertTrue(state.TryAdmit(captured, true), "initial snapshot was never applied");
+        }
+
+        private static void PathProbeBackpressureHandlesMaximumCounters()
+        {
+            AssertEqual(
+                4L,
+                PathProbeBackpressure.ComputeQueueQuota(int.MaxValue, 0),
+                "large worker pool saturates quota without overflow");
+            AssertEqual(
+                1L,
+                PathProbeBackpressure.ComputeQueueQuota(int.MaxValue, int.MaxValue),
+                "equal maximum counters retain minimum quota");
+            AssertEqual(
+                1L,
+                PathProbeBackpressure.ComputeQueueQuota(0, int.MaxValue),
+                "maximum in-flight count retains minimum quota");
+        }
+
+        private static void CompleteProbe(PathProbeAdmissionState state, PathProbeStamp stamp)
+        {
+            AssertTrue(state.TryAdmit(stamp, true), "probe admitted");
+            state.MarkDequeued();
+            state.MarkApplied();
+        }
+
+        private static PathProbeStamp CreateRegressionStamp(int context)
+        {
+            return new PathProbeStamp(1, context, 1UL, 1, 0, false, 1, 1);
+        }
+    }
+}

--- a/benchmarks/CycleTrim.BrainBenchmarks/PathProbeWorkOrderAdapterSimulator.cs
+++ b/benchmarks/CycleTrim.BrainBenchmarks/PathProbeWorkOrderAdapterSimulator.cs
@@ -9,12 +9,17 @@ namespace CycleTrim.BrainBenchmarks
 
         internal void Prepare(bool exactCreature, bool sentinelSafe, bool completedHit)
         {
-            if (!sentinelSafe || !exactCreature)
+            if (!sentinelSafe)
             {
                 return;
             }
-            RefreshCalls++;
             StateLookups++;
+            if (!exactCreature)
+            {
+                // Unsupported work invalidates any existing tracked state.
+                return;
+            }
+            RefreshCalls++;
             if (completedHit)
             {
                 RecycleCalls++;

--- a/benchmarks/CycleTrim.BrainBenchmarks/Program.cs
+++ b/benchmarks/CycleTrim.BrainBenchmarks/Program.cs
@@ -3,7 +3,7 @@ using CycleTrim.Core;
 
 namespace CycleTrim.BrainBenchmarks
 {
-    internal static class Program
+    internal static partial class Program
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Design",
@@ -103,6 +103,7 @@ namespace CycleTrim.BrainBenchmarks
                 RunTest(
                     nameof(PathProbeWorkOrderAdapterUsesExactRefreshAndCloneCounts),
                     PathProbeWorkOrderAdapterUsesExactRefreshAndCloneCounts);
+                RunPathProbeRegressionTests();
                 return 0;
             }
             catch (Exception exception)
@@ -326,7 +327,7 @@ namespace CycleTrim.BrainBenchmarks
             var adapter = new PathProbeWorkOrderAdapterSimulator();
             adapter.Prepare(exactCreature: false, sentinelSafe: true, completedHit: false);
             AssertEqual(0L, adapter.RefreshCalls, "unsupported zero refresh");
-            AssertEqual(0L, adapter.StateLookups, "unsupported zero state");
+            AssertEqual(1L, adapter.StateLookups, "unsupported checks existing state for invalidation");
 
             adapter.ResetCounts();
             adapter.Prepare(exactCreature: true, sentinelSafe: true, completedHit: false);

--- a/docs/mod-testing.md
+++ b/docs/mod-testing.md
@@ -1,0 +1,39 @@
+# Mod regression checks
+
+Run the same checks as the `Mod quality` GitHub Actions workflow:
+
+```sh
+python3 scripts/check_mods.py
+```
+
+Requirements: Python 3 and .NET SDK 10. The first C# run restores Newtonsoft.Json
+from NuGet. The checks do not require a Steam installation, game assemblies, or
+local `Directory.Build.props`. Use `--dotnet /path/to/dotnet` for an SDK outside
+`PATH`, or `--static-only` to run just the Python source contracts.
+
+The runner executes source contracts, every console regression project under
+`tests/`, and the existing CycleTrim policy assertions. Each console exits with a
+nonzero code on failure. These projects link production sources and use small
+stubs where game APIs would otherwise be required. They exercise the linked
+logic; they do not validate Unity behavior or Harmony patch compatibility.
+
+## Game-dependent checks
+
+The standalone runner lists these as **NOT RUN**. Before shipping a Mod release,
+configure the game path using `Directory.Build.props.example`, build both Mods,
+and run:
+
+```sh
+dotnet build mods/OniMcp/OniMcp.csproj -c Debug -warnaserror
+dotnet build mods/CycleTrim/CycleTrim.csproj -c Release -warnaserror
+python3 scripts/verify_restart_packaging.py
+python3 scripts/verify_cycletrim_release_binary.py
+python3 scripts/verify_cycletrim_target_contract.py /path/to/Assembly-CSharp.dll
+```
+
+The CycleTrim assembly checks require `ilspycmd`. Also check the Mods inside ONI:
+connect an MCP client, read resources, execute a batch containing a failing call,
+restart the server with an open event stream, and load a colony with idle and
+busy duplicants and moving critters. Verify that navigation, priority updates,
+and immediate fallback behavior remain correct. Timing results from the policy
+benchmark do not establish an in-game FPS improvement.

--- a/mods/CycleTrim/CHANGELOG.md
+++ b/mods/CycleTrim/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Generated from `git log -- mods/CycleTrim`.
 
+## Unreleased
+
+- Invalidate path-probe results when replacement work is queued, discarded, unsupported, or fails; invalidate cached navigation state when the `NavGrid` object changes.
+- Preserve immediate fallback for unsupported critter abilities and invalid cells, and avoid integer overflow when calculating worker admission limits.
+- Add six executable policy regression groups. Game assembly compatibility and in-game performance still require release validation.
+
 ## 2026-08-23
 
 - CycleTrim 现在识别 ONI 的非空回退差事 `IdleChore`，空闲复制人的拾取和差事刷新直接走原版即时路径。

--- a/mods/CycleTrim/Core/PathProbePolicy.cs
+++ b/mods/CycleTrim/Core/PathProbePolicy.cs
@@ -105,6 +105,9 @@ namespace CycleTrim.Core
         {
             if (!supported)
             {
+                // Vanilla may replace the navigator's result with a probe whose
+                // abilities cannot be represented by this cache key.
+                Reset();
                 return true;
             }
             if (hasCompleted
@@ -117,12 +120,17 @@ namespace CycleTrim.Core
 
             queued = stamp;
             hasQueued = true;
+            // A replacement or bounded fallback must complete before another
+            // hit is possible, including when this queued order is discarded.
+            hasCompleted = false;
             consecutiveSkips = 0;
             return true;
         }
 
         public void MarkDequeued()
         {
+            // An untracked order must never inherit an earlier pending result.
+            hasInFlight = false;
             if (!hasQueued)
             {
                 return;
@@ -178,7 +186,7 @@ namespace CycleTrim.Core
             {
                 throw new ArgumentOutOfRangeException(nameof(inFlightCount));
             }
-            return Math.Max(1, Math.Min(4, workerCount + 1 - inFlightCount));
+            return (int)Math.Max(1L, Math.Min(4L, (long)workerCount + 1 - inFlightCount));
         }
     }
 }

--- a/mods/CycleTrim/Patches/AsyncPathProbeOptimizationPatch.cs
+++ b/mods/CycleTrim/Patches/AsyncPathProbeOptimizationPatch.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -35,7 +36,7 @@ namespace CycleTrim.Patches
         {
             internal readonly ConditionalWeakTable<Navigator, NavigatorState> Navigators =
                 new ConditionalWeakTable<Navigator, NavigatorState>();
-            internal int Tick;
+            internal volatile int Tick;
         }
 
         private sealed class NavigatorState
@@ -43,6 +44,7 @@ namespace CycleTrim.Patches
             internal readonly PathProbeAdmissionState Admission =
                 new PathProbeAdmissionState(MaxConsecutiveSkips);
             internal int LastTick = -1;
+            internal NavGrid NavGrid;
         }
 
         private static bool IsCompatible()
@@ -81,15 +83,31 @@ namespace CycleTrim.Patches
         {
             var managerState = States.GetValue(manager, StateFactory);
             var state = managerState.Navigators.GetOrCreateValue(navigator);
-            if (state.LastTick != managerState.Tick)
+            lock (state.Admission)
             {
-                lock (state.Admission)
+                if (state.LastTick != managerState.Tick)
                 {
                     state.Admission.BeginTick();
                     state.LastTick = managerState.Tick;
                 }
             }
             return state;
+        }
+
+        private static void ResetNavigatorState(
+            AsyncPathProber.Manager manager,
+            Navigator navigator)
+        {
+            ManagerState managerState;
+            NavigatorState state;
+            if (States.TryGetValue(manager, out managerState)
+                && managerState.Navigators.TryGetValue(navigator, out state))
+            {
+                lock (state.Admission)
+                {
+                    state.Admission.Reset();
+                }
+            }
         }
 
         private static PathProbeStamp CreateStamp(
@@ -170,8 +188,13 @@ namespace CycleTrim.Patches
                     if (list[index].opcode == OpCodes.Ldc_I4_4)
                     {
                         matches++;
-                        var labels = list[index].labels;
-                        list[index] = new CodeInstruction(OpCodes.Ldarg_0) { labels = labels };
+                        // Preserve branch labels and exception boundaries on
+                        // the first instruction replacing the original constant.
+                        list[index] = new CodeInstruction(list[index])
+                        {
+                            opcode = OpCodes.Ldarg_0,
+                            operand = null
+                        };
                         list.Insert(index + 1, new CodeInstruction(OpCodes.Call, replacement));
                         index++;
                     }
@@ -208,6 +231,7 @@ namespace CycleTrim.Patches
                 if (rawAbilities == null
                     || rawAbilities.GetType() != typeof(CreaturePathFinderAbilities))
                 {
+                    ResetNavigatorState(__instance, nav);
                     return true;
                 }
 
@@ -217,6 +241,13 @@ namespace CycleTrim.Patches
                 var admitted = false;
                 lock (state.Admission)
                 {
+                    // Navigation generations are scoped per grid; equal
+                    // counters from different grids do not identify equal paths.
+                    if (!ReferenceEquals(state.NavGrid, nav.NavGrid))
+                    {
+                        state.Admission.Reset();
+                        state.NavGrid = nav.NavGrid;
+                    }
                     admitted = state.Admission.TryAdmit(stamp, supported: true);
                 }
                 if (admitted)
@@ -248,6 +279,18 @@ namespace CycleTrim.Patches
                     };
                 }
                 return false;
+            }
+
+            private static Exception Finalizer(
+                Exception __exception,
+                AsyncPathProber.Manager __instance,
+                Navigator nav)
+            {
+                if (__exception != null && !ReferenceEquals(nav, null))
+                {
+                    ResetNavigatorState(__instance, nav);
+                }
+                return __exception;
             }
         }
 
@@ -289,6 +332,16 @@ namespace CycleTrim.Patches
                         state.Admission.MarkApplied();
                     }
                 }
+            }
+
+            private static Exception Finalizer(Exception __exception, Navigator __instance)
+            {
+                var manager = AsyncPathProber.Instance;
+                if (__exception != null && manager != null)
+                {
+                    ResetNavigatorState(manager, __instance);
+                }
+                return __exception;
             }
         }
 

--- a/mods/CycleTrim/Patches/BusyDuplicantChoreThrottlePatch.cs
+++ b/mods/CycleTrim/Patches/BusyDuplicantChoreThrottlePatch.cs
@@ -21,6 +21,7 @@ namespace CycleTrim.Patches
                 new VersionedRefreshGate(4);
             internal readonly VersionedRefreshGate ChoreGate =
                 new VersionedRefreshGate(4);
+            internal NavGrid NavGrid;
 
             internal void Invalidate()
             {
@@ -65,10 +66,17 @@ namespace CycleTrim.Patches
         }
 
         private static RefreshStamp CaptureStamp(
+            State state,
             ChoreConsumer consumer,
             Navigator navigator,
             Chore currentChore)
         {
+            if (!ReferenceEquals(state.NavGrid, navigator.NavGrid))
+            {
+                state.Reset();
+                state.NavGrid = navigator.NavGrid;
+            }
+
             ScheduleBlock scheduleBlock = null;
             var consumerState = consumer.consumerState;
             var schedulable = consumerState == null ? null : consumerState.schedulable;
@@ -127,7 +135,7 @@ namespace CycleTrim.Patches
                 }
 
                 return state.PickupGate.ShouldRefresh(
-                    CaptureStamp(consumer, navigator, currentChore));
+                    CaptureStamp(state, consumer, navigator, currentChore));
             }
         }
 
@@ -174,7 +182,7 @@ namespace CycleTrim.Patches
                 }
 
                 if (state.ChoreGate.ShouldRefresh(
-                    CaptureStamp(__instance, navigator, currentChore)))
+                    CaptureStamp(state, __instance, navigator, currentChore)))
                 {
                     return true;
                 }

--- a/mods/CycleTrim/Patches/StationaryCritterNavigationThrottlePatch.cs
+++ b/mods/CycleTrim/Patches/StationaryCritterNavigationThrottlePatch.cs
@@ -20,6 +20,7 @@ namespace CycleTrim.Patches
         {
             internal readonly VersionedRefreshGate Gate =
                 new VersionedRefreshGate(8);
+            internal NavGrid NavGrid;
         }
 
         private static State CreateState(Navigator navigator)
@@ -95,7 +96,9 @@ namespace CycleTrim.Patches
                 || __instance.IsMoving()
                 || ___reportOccupation
                 || ___executePathProbeTaskAsync
-                || !(___abilities is CreaturePathFinderAbilities)
+                || ___abilities == null
+                || ___abilities.GetType() != typeof(CreaturePathFinderAbilities)
+                || !Grid.IsValidCell(Grid.PosToCell(__instance))
                 || __instance.GetComponent<CreatureBrain>() == null)
             {
                 if (States.TryGetValue(__instance, out var preservedState))
@@ -107,6 +110,11 @@ namespace CycleTrim.Patches
             }
 
             var state = States.GetValue(__instance, StateFactory);
+            if (!ReferenceEquals(state.NavGrid, __instance.NavGrid))
+            {
+                state.Gate.Reset();
+                state.NavGrid = __instance.NavGrid;
+            }
             return state.Gate.ShouldRefresh(
                 CaptureStamp(
                     __instance,

--- a/mods/OniMcp/CHANGELOG.md
+++ b/mods/OniMcp/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Generated from `git log -- mods/OniMcp`.
 
+## Unreleased
+
+- Fix resource dispatch and JSON-RPC null responses; preserve tool visibility and protect cached metadata from caller mutation.
+- Cancel queued main-thread calls after timeout; clean up sessions and restrict task access to the owning session.
+- Save configuration through an atomic replacement and preserve existing settings when a reload fails. Invalid configuration on first load now stops initialization instead of replacing the file with defaults.
+- Report failed batch operations as errors, validate agent program structure before execution, and bound user-supplied regular expression matching.
+- Add executable regression suites and a shared `scripts/check_mods.py` CI entry point. Full game builds and Unity/Harmony integration remain separate release checks.
+
 ## 2026-08-23 — 0.2.2
 
 - 移除 OniMcp 源码中的 680 条未使用 `using`，补齐解决方案与 .NET Framework 引用程序集配置；Release 构建在警告即错误模式下通过。

--- a/mods/OniMcp/Config/OniMcpOptions.cs
+++ b/mods/OniMcp/Config/OniMcpOptions.cs
@@ -16,7 +16,8 @@ namespace OniMcp.Config
     [ModInfo("https://steamcommunity.com/sharedfiles/filedetails/?id=3731864673", "preview.png")]
     public class OniMcpOptions : IOptions
     {
-        private static OniMcpOptions _current;
+        private static readonly object SyncRoot = new object();
+        private static volatile OniMcpOptions _current;
         private const int CurrentSecurityMigrationVersion = 1;
 
         public int SecurityMigrationVersion { get; set; } = CurrentSecurityMigrationVersion;
@@ -70,9 +71,15 @@ namespace OniMcp.Config
         {
             get
             {
-                if (_current == null)
-                    _current = Load();
-                return _current;
+                var current = _current;
+                if (current != null)
+                    return current;
+                lock (SyncRoot)
+                {
+                    if (_current == null)
+                        _current = Load();
+                    return _current;
+                }
             }
         }
 
@@ -112,20 +119,46 @@ namespace OniMcp.Config
 
         public static void Reload()
         {
-            _current = Load();
+            lock (SyncRoot)
+                _current = Load();
         }
 
         public static void Save(OniMcpOptions options)
         {
-            options = Sanitize(options);
-            string path = ConfigPath;
-            string dir = Path.GetDirectoryName(path);
-            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
+            lock (SyncRoot)
+            {
+                options = Sanitize(options);
+                string path = ConfigPath;
+                if (string.IsNullOrEmpty(path))
+                    throw new InvalidOperationException("The config path is not available.");
+                string dir = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(dir))
+                    Directory.CreateDirectory(dir);
 
-            string json = JsonConvert.SerializeObject(options, Formatting.Indented);
-            File.WriteAllText(path, json);
-            _current = options;
+                string json = JsonConvert.SerializeObject(options, Formatting.Indented);
+                // Keep the original file intact until its replacement has been fully written.
+                string temporaryPath = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+                try
+                {
+                    File.WriteAllText(temporaryPath, json);
+                    if (File.Exists(path))
+                        File.Replace(temporaryPath, path, null);
+                    else
+                        File.Move(temporaryPath, path);
+                    _current = options;
+                }
+                finally
+                {
+                    try
+                    {
+                        File.Delete(temporaryPath);
+                    }
+                    catch (Exception ex)
+                    {
+                        OniMcpLog.Warning("[OniMcp] Failed to remove temporary config " + temporaryPath + ": " + ex.Message);
+                    }
+                }
+            }
         }
 
         public IEnumerable<IOptionsEntry> CreateOptions()
@@ -203,13 +236,6 @@ namespace OniMcp.Config
         private static OniMcpOptions Load()
         {
             string path = ConfigPath;
-            if (string.IsNullOrEmpty(path) || !File.Exists(path))
-            {
-                var created = Sanitize(new OniMcpOptions());
-                TrySave(created);
-                return created;
-            }
-
             try
             {
                 string json = File.ReadAllText(path);
@@ -220,12 +246,19 @@ namespace OniMcp.Config
                 TrySave(options);
                 return options;
             }
+            catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
+            {
+                var created = Sanitize(new OniMcpOptions());
+                TrySave(created);
+                return created;
+            }
             catch (Exception ex)
             {
                 OniMcpLog.Warning("[OniMcp] Failed to read config " + path + ": " + ex.Message);
-                var fallback = Sanitize(new OniMcpOptions());
-                TrySave(fallback);
-                return fallback;
+                // A transient read failure must not overwrite the user's settings or token.
+                if (_current != null)
+                    return _current;
+                throw new InvalidOperationException("Cannot load OniMcp config " + path + ". Fix the file before starting the server.", ex);
             }
         }
 

--- a/mods/OniMcp/Core/McpTypes.cs
+++ b/mods/OniMcp/Core/McpTypes.cs
@@ -37,14 +37,16 @@ namespace OniMcp.Core
         [JsonProperty("jsonrpc")]
         public string JsonRpc { get; set; } = "2.0";
 
-        [JsonProperty("id")]
+        [JsonProperty("id", NullValueHandling = NullValueHandling.Include)]
         public object Id { get; set; }
 
-        [JsonProperty("result")]
+        [JsonProperty("result", NullValueHandling = NullValueHandling.Include)]
         public object Result { get; set; }
 
-        [JsonProperty("error")]
+        [JsonProperty("error", NullValueHandling = NullValueHandling.Ignore)]
         public JsonRpcError Error { get; set; }
+
+        public bool ShouldSerializeResult() => Error == null;
 
         public static JsonRpcResponse Success(object id, object result)
         {

--- a/mods/OniMcp/Server/HttpRequestBody.cs
+++ b/mods/OniMcp/Server/HttpRequestBody.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace OniMcp.Server
+{
+    internal static class HttpRequestBody
+    {
+        internal const int MaxMcpBytes = 16 * 1024 * 1024;
+        internal const int MaxSettingsBytes = 64 * 1024;
+
+        internal static string Read(Stream stream, Encoding encoding, long contentLength, int maxBytes)
+        {
+            if (contentLength > maxBytes)
+                throw new RequestBodyTooLargeException();
+
+            using (var body = new MemoryStream())
+            {
+                var buffer = new byte[8192];
+                int count;
+                while ((count = stream.Read(buffer, 0, (int)Math.Min(buffer.Length, maxBytes - body.Length + 1))) > 0)
+                {
+                    if (body.Length + count > maxBytes)
+                        throw new RequestBodyTooLargeException();
+                    body.Write(buffer, 0, count);
+                }
+                body.Position = 0;
+                using (var reader = new StreamReader(body, encoding))
+                    return reader.ReadToEnd();
+            }
+        }
+    }
+
+    internal sealed class RequestBodyTooLargeException : IOException
+    {
+        internal RequestBodyTooLargeException() : base("Request body exceeds the allowed size.") { }
+    }
+}

--- a/mods/OniMcp/Server/MainThreadBridge.cs
+++ b/mods/OniMcp/Server/MainThreadBridge.cs
@@ -12,14 +12,17 @@ namespace OniMcp.Server
     /// </summary>
     public class MainThreadBridge : MonoBehaviour
     {
-        public static MainThreadBridge Instance { get; private set; }
+        private static MainThreadBridge _instance;
+        public static MainThreadBridge Instance => Volatile.Read(ref _instance);
 
         private readonly Queue<System.Action> _queueA = new Queue<System.Action>();
         private readonly Queue<System.Action> _queueB = new Queue<System.Action>();
         private readonly object _queueLock = new object();
+        private readonly HashSet<System.Action> _pendingCancellations = new HashSet<System.Action>();
         private Queue<System.Action> _enqueueQueue;
         private Queue<System.Action> _dequeueQueue;
         private int _mainThreadId;
+        private bool _destroyed;
 
         private void Awake()
         {
@@ -28,11 +31,11 @@ namespace OniMcp.Server
                 Destroy(gameObject);
                 return;
             }
-            Instance = this;
             _enqueueQueue = _queueA;
             _dequeueQueue = _queueB;
             _mainThreadId = Thread.CurrentThread.ManagedThreadId;
             DontDestroyOnLoad(gameObject);
+            Volatile.Write(ref _instance, this);
         }
 
         private void Update()
@@ -71,7 +74,7 @@ namespace OniMcp.Server
             return _mainThreadId != 0 && Thread.CurrentThread.ManagedThreadId == _mainThreadId;
         }
 
-        private void EnqueueInstance(System.Action action, bool allowInline)
+        private void EnqueueInstance(System.Action action, bool allowInline, System.Action cancel = null)
         {
             if (allowInline && IsMainThread())
             {
@@ -81,6 +84,22 @@ namespace OniMcp.Server
 
             lock (_queueLock)
             {
+                if (_destroyed)
+                    throw new InvalidOperationException("Unity main thread bridge has been destroyed.");
+                if (cancel != null)
+                {
+                    var pendingAction = action;
+                    action = () =>
+                    {
+                        try { pendingAction(); }
+                        finally
+                        {
+                            lock (_queueLock)
+                                _pendingCancellations.Remove(cancel);
+                        }
+                    };
+                    _pendingCancellations.Add(cancel);
+                }
                 _enqueueQueue.Enqueue(action);
             }
         }
@@ -90,14 +109,9 @@ namespace OniMcp.Server
         /// </summary>
         public static void Enqueue(System.Action action)
         {
-            if (Instance == null)
-            {
-                OniMcpLog.Warning("[OniMcp] MainThreadBridge not initialized, executing inline");
-                action();
-                return;
-            }
-
-            Instance.EnqueueInstance(action, allowInline: true);
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+            RequireInstance().EnqueueInstance(action, allowInline: true);
         }
 
         /// <summary>
@@ -105,14 +119,9 @@ namespace OniMcp.Server
         /// </summary>
         public static void EnqueueDeferred(System.Action action)
         {
-            if (Instance == null)
-            {
-                OniMcpLog.Warning("[OniMcp] MainThreadBridge not initialized, executing inline");
-                action();
-                return;
-            }
-
-            Instance.EnqueueInstance(action, allowInline: false);
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+            RequireInstance().EnqueueInstance(action, allowInline: false);
         }
 
         public static T Invoke<T>(Func<T> func, int timeoutMs = 10000)
@@ -120,48 +129,41 @@ namespace OniMcp.Server
             if (func == null)
                 throw new ArgumentNullException(nameof(func));
 
-            if (Instance == null)
-            {
-                OniMcpLog.Warning("[OniMcp] MainThreadBridge not initialized, executing inline");
-                return func();
-            }
-
-            if (Instance.IsMainThread())
+            if (timeoutMs < Timeout.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(timeoutMs));
+            var instance = RequireInstance();
+            if (instance.IsMainThread())
                 return func();
 
-            T result = default(T);
-            Exception error = null;
-            using (var done = new ManualResetEventSlim(false))
-            {
-                Instance.EnqueueInstance(() =>
-                {
-                    try
-                    {
-                        result = func();
-                    }
-                    catch (Exception ex)
-                    {
-                        error = ex;
-                    }
-                    finally
-                    {
-                        done.Set();
-                    }
-                }, allowInline: false);
+            var invocation = new MainThreadInvocation<T>(func);
+            instance.EnqueueInstance(invocation.Execute, allowInline: false, cancel: invocation.Cancel);
+            return invocation.Wait(timeoutMs);
+        }
 
-                if (!done.Wait(timeoutMs))
-                    throw new TimeoutException("Timed out waiting for Unity main thread.");
-            }
-
-            if (error != null)
-                throw error;
-            return result;
+        private static MainThreadBridge RequireInstance()
+        {
+            var instance = Instance;
+            // Unity's overloaded null comparison is not safe to use on HTTP worker threads.
+            if (ReferenceEquals(instance, null))
+                throw new InvalidOperationException("Unity main thread bridge is not initialized.");
+            return instance;
         }
 
         private void OnDestroy()
         {
-            if (Instance == this)
-                Instance = null;
+            Interlocked.CompareExchange(ref _instance, null, this);
+            System.Action[] cancellations;
+            lock (_queueLock)
+            {
+                _destroyed = true;
+                cancellations = new System.Action[_pendingCancellations.Count];
+                _pendingCancellations.CopyTo(cancellations);
+                _pendingCancellations.Clear();
+                _queueA.Clear();
+                _queueB.Clear();
+            }
+            foreach (var cancel in cancellations)
+                cancel();
         }
     }
 }

--- a/mods/OniMcp/Server/MainThreadInvocation.cs
+++ b/mods/OniMcp/Server/MainThreadInvocation.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+
+namespace OniMcp.Server
+{
+    /// <summary>A timed-out queued invocation must never start changing game state.</summary>
+    internal sealed class MainThreadInvocation<T>
+    {
+        private readonly object _gate = new object();
+        private readonly Func<T> _action;
+        private bool _started;
+        private bool _completed;
+        private bool _cancelled;
+        private T _result;
+        private ExceptionDispatchInfo _error;
+
+        internal MainThreadInvocation(Func<T> action)
+        {
+            _action = action ?? throw new ArgumentNullException(nameof(action));
+        }
+
+        internal void Execute()
+        {
+            lock (_gate)
+            {
+                if (_cancelled || _started)
+                    return;
+                _started = true;
+            }
+
+            T result = default(T);
+            ExceptionDispatchInfo error = null;
+            try { result = _action(); }
+            catch (Exception ex) { error = ExceptionDispatchInfo.Capture(ex); }
+
+            lock (_gate)
+            {
+                if (_completed)
+                    return;
+                _result = result;
+                _error = error;
+                _completed = true;
+                Monitor.PulseAll(_gate);
+            }
+        }
+
+        internal void Cancel()
+        {
+            lock (_gate)
+            {
+                if (_completed)
+                    return;
+                _cancelled = true;
+                _error = ExceptionDispatchInfo.Capture(new InvalidOperationException("Unity main thread bridge has been destroyed."));
+                _completed = true;
+                Monitor.PulseAll(_gate);
+            }
+        }
+
+        internal T Wait(int timeoutMs)
+        {
+            if (timeoutMs < Timeout.Infinite)
+                throw new ArgumentOutOfRangeException(nameof(timeoutMs));
+
+            var elapsed = Stopwatch.StartNew();
+            lock (_gate)
+            {
+                while (!_completed)
+                {
+                    int remaining = timeoutMs == Timeout.Infinite
+                        ? Timeout.Infinite
+                        : (int)Math.Max(0L, timeoutMs - elapsed.ElapsedMilliseconds);
+                    if (remaining == 0 || !Monitor.Wait(_gate, remaining))
+                    {
+                        // A running Unity call cannot be interrupted; it can safely complete later.
+                        _cancelled = !_started;
+                        throw new TimeoutException("Timed out waiting for Unity main thread.");
+                    }
+                }
+                _error?.Throw();
+                return _result;
+            }
+        }
+    }
+}

--- a/mods/OniMcp/Server/McpHttpServer.cs
+++ b/mods/OniMcp/Server/McpHttpServer.cs
@@ -28,8 +28,6 @@ namespace OniMcp.Server
 
         private readonly Dictionary<string, McpSession> _sessions = new Dictionary<string, McpSession>();
 
-        private readonly HashSet<string> _terminatedSessions = new HashSet<string>();
-
         private readonly object _sessionLock = new object();
 
         private readonly Dictionary<string, McpTaskEntry> _tasks = new Dictionary<string, McpTaskEntry>();
@@ -85,7 +83,8 @@ namespace OniMcp.Server
                 _listener.Start();
                 _running = true;
 
-                _listenerThread = new Thread(ListenLoop)
+                var listener = _listener;
+                _listenerThread = new Thread(() => ListenLoop(listener))
                 {
                     IsBackground = true,
                     Name = "OniMcpHttpListener"
@@ -96,6 +95,9 @@ namespace OniMcp.Server
             }
             catch (Exception ex)
             {
+                _running = false;
+                try { _listener?.Close(); } catch { }
+                _listener = null;
                 OniMcpLog.Error($"[OniMcp] Failed to start MCP Server: {ex.Message}");
             }
         }
@@ -124,8 +126,9 @@ namespace OniMcp.Server
 
             lock (_sessionLock)
             {
+                foreach (var session in _sessions.Values)
+                    session.Close();
                 _sessions.Clear();
-                _terminatedSessions.Clear();
             }
             lock (_taskLock)
             {
@@ -137,14 +140,20 @@ namespace OniMcp.Server
             OniMcpLog.Debug("[OniMcp] MCP Server stopped.");
         }
 
-        private void ListenLoop()
+        private void ListenLoop(HttpListener listener)
         {
-            while (_running)
+            while (_running && ReferenceEquals(listener, _listener))
             {
                 try
                 {
-                    var context = _listener.GetContext();
-                    ThreadPool.QueueUserWorkItem(_ => ProcessRequest(context));
+                    var context = listener.GetContext();
+                    ThreadPool.QueueUserWorkItem(_ =>
+                    {
+                        if (_running && ReferenceEquals(listener, _listener))
+                            ProcessRequest(context);
+                        else
+                            try { context.Response.Close(); } catch { }
+                    });
                 }
                 catch (HttpListenerException)
                 {

--- a/mods/OniMcp/Server/McpHttpServerJsonSse.cs
+++ b/mods/OniMcp/Server/McpHttpServerJsonSse.cs
@@ -67,13 +67,17 @@ namespace OniMcp.Server
                     .ToList();
             }
 
+            int queued = 0;
             foreach (var session in sessions)
-                session.EnqueueOutbound(CloneOutboundMessage(request));
+            {
+                if (session.EnqueueOutbound(CloneOutboundMessage(request)))
+                    queued++;
+            }
 
-            if (sessions.Count > 0)
-                OniMcpLog.Debug($"[OniMcp] Queued client request {request["method"]} for {sessions.Count} session(s).");
+            if (queued > 0)
+                OniMcpLog.Debug($"[OniMcp] Queued client request {request["method"]} for {queued} session(s).");
 
-            return sessions.Count;
+            return queued;
         }
 
         public int EnqueueClientNotification(string level, string logger, object data)

--- a/mods/OniMcp/Server/McpHttpServerModels.cs
+++ b/mods/OniMcp/Server/McpHttpServerModels.cs
@@ -14,8 +14,10 @@ namespace OniMcp.Server
     /// </summary>
     public class McpSession
     {
+        internal const int MaxQueuedOutboundMessages = 256;
         private readonly Queue<JObject> _outboundQueue = new Queue<JObject>();
         private readonly object _outboundLock = new object();
+        private bool _closed;
 
         public string Id { get; set; }
         public System.DateTime CreatedAt { get; set; }
@@ -23,7 +25,6 @@ namespace OniMcp.Server
         public Implementation ClientInfo { get; set; }
         public ClientCapabilities Capabilities { get; set; }
         public int SseConnections { get; set; }
-        public AutoResetEvent OutboundSignal { get; } = new AutoResetEvent(false);
 
         public int QueuedOutboundCount
         {
@@ -36,16 +37,38 @@ namespace OniMcp.Server
             }
         }
 
-        public void EnqueueOutbound(JObject message)
+        public bool EnqueueOutbound(JObject message)
         {
             if (message == null)
-                return;
+                return false;
 
             lock (_outboundLock)
             {
+                if (_closed || _outboundQueue.Count >= MaxQueuedOutboundMessages)
+                    return false;
                 _outboundQueue.Enqueue(message);
+                Monitor.PulseAll(_outboundLock);
+                return true;
             }
-            OutboundSignal.Set();
+        }
+
+        public void WaitForOutbound(int timeoutMs)
+        {
+            lock (_outboundLock)
+            {
+                if (!_closed && _outboundQueue.Count == 0)
+                    Monitor.Wait(_outboundLock, timeoutMs);
+            }
+        }
+
+        public void Close()
+        {
+            lock (_outboundLock)
+            {
+                _closed = true;
+                _outboundQueue.Clear();
+                Monitor.PulseAll(_outboundLock);
+            }
         }
 
         public JObject TryDequeueOutbound()
@@ -60,6 +83,7 @@ namespace OniMcp.Server
     public class McpTaskEntry
     {
         public string TaskId { get; set; }
+        public string SessionId { get; set; }
         public string Status { get; set; }
         public string StatusMessage { get; set; }
         public System.DateTime CreatedAt { get; set; }

--- a/mods/OniMcp/Server/McpHttpServerPostTransport.cs
+++ b/mods/OniMcp/Server/McpHttpServerPostTransport.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Text;
 using System.Threading;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OniMcp.Config;
 using OniMcp.Core;
@@ -20,9 +21,14 @@ namespace OniMcp.Server
         private void HandlePost(HttpListenerRequest request, HttpListenerResponse response, string sessionId, string protocolVersion)
         {
             string body;
-            using (var reader = new StreamReader(request.InputStream, Encoding.UTF8))
+            try
             {
-                body = reader.ReadToEnd();
+                body = HttpRequestBody.Read(request.InputStream, Encoding.UTF8, request.ContentLength64, HttpRequestBody.MaxMcpBytes);
+            }
+            catch (RequestBodyTooLargeException ex)
+            {
+                SendJson(response, JsonRpcResponse.MakeError(null, McpErrorCode.InvalidRequest, ex.Message), 413);
+                return;
             }
 
             if (string.IsNullOrEmpty(body))
@@ -36,9 +42,18 @@ namespace OniMcp.Server
             {
                 rawMessage = JObject.Parse(body);
             }
-            catch (Exception ex)
+            catch (JsonException ex)
             {
                 SendJson(response, JsonRpcResponse.MakeError(null, McpErrorCode.ParseError, $"Parse error: {ex.Message}"), 200);
+                return;
+            }
+
+            var requestId = rawMessage["id"];
+            if (rawMessage["jsonrpc"]?.Type != JTokenType.String || (string)rawMessage["jsonrpc"] != "2.0"
+                || (requestId != null && requestId.Type != JTokenType.Null && requestId.Type != JTokenType.String
+                    && requestId.Type != JTokenType.Integer && requestId.Type != JTokenType.Float))
+            {
+                SendJson(response, JsonRpcResponse.MakeError(null, McpErrorCode.InvalidRequest, "Invalid JSON-RPC request"), 200);
                 return;
             }
 
@@ -56,12 +71,18 @@ namespace OniMcp.Server
                 return;
             }
 
+            if (rawMessage["method"]?.Type != JTokenType.String)
+            {
+                SendJson(response, JsonRpcResponse.MakeError(requestId, McpErrorCode.InvalidRequest, "Missing or invalid JSON-RPC method"), 200);
+                return;
+            }
+
             JsonRpcRequest rpcRequest;
             try
             {
                 rpcRequest = rawMessage.ToObject<JsonRpcRequest>();
             }
-            catch (Exception ex)
+            catch (JsonException ex)
             {
                 SendJson(response, JsonRpcResponse.MakeError(null, McpErrorCode.ParseError, $"Parse error: {ex.Message}"), 200);
                 return;
@@ -74,6 +95,15 @@ namespace OniMcp.Server
             }
 
             bool isInitialize = rpcRequest.Method == "initialize";
+            bool isNotification = rawMessage.Property("id") == null;
+            var initializeVersion = rpcRequest.Params?["protocolVersion"];
+            if (isInitialize && (isNotification || initializeVersion?.Type != JTokenType.String
+                || !IsSupportedProtocolVersion((string)initializeVersion)))
+            {
+                SendJson(response, JsonRpcResponse.MakeError(rpcRequest.Id, McpErrorCode.InvalidParams,
+                    "initialize requires a request id and a supported protocolVersion"), 200);
+                return;
+            }
             if (!isInitialize)
             {
                 if (!ValidateNonInitRequest(response, sessionId, protocolVersion))
@@ -85,13 +115,21 @@ namespace OniMcp.Server
             }
 
             if (isInitialize)
+            {
                 sessionId = EnsureSession(response, sessionId);
+                if (sessionId == null)
+                    return;
+            }
 
             // 通知（无 id）：返回 202 Accepted
-            if (rpcRequest.IsNotification)
+            if (isNotification)
             {
                 // 在后台处理通知
-                MainThreadBridge.Enqueue(new System.Action(() => ProcessMethod(rpcRequest, sessionId)));
+                MainThreadBridge.Enqueue(new System.Action(() =>
+                {
+                    if (_running && IsSessionActive(sessionId))
+                        ProcessMethod(rpcRequest, sessionId);
+                }));
                 SetResponseSessionId(response, sessionId);
                 SetResponseProtocolVersion(response, sessionId);
                 response.StatusCode = 202;
@@ -199,7 +237,9 @@ namespace OniMcp.Server
                 Exception processEx = null;
                 try
                 {
-                    result = ProcessMethod(rpcRequest, sessionId);
+                    result = _running && IsSessionActive(sessionId)
+                        ? ProcessMethod(rpcRequest, sessionId)
+                        : JsonRpcResponse.MakeError(rpcRequest.Id, McpErrorCode.InvalidRequest, "Session not found or terminated");
                 }
                 catch (Exception ex)
                 {

--- a/mods/OniMcp/Server/McpHttpServerProtocolTasks.cs
+++ b/mods/OniMcp/Server/McpHttpServerProtocolTasks.cs
@@ -159,6 +159,7 @@ namespace OniMcp.Server
                 return new ListTasksResult
                 {
                     Tasks = _tasks.Values
+                        .Where(task => string.Equals(task.SessionId, CurrentSessionId, StringComparison.Ordinal))
                         .OrderByDescending(task => task.CreatedAt)
                         .Select(task => task.ToInfo())
                         .ToList()
@@ -224,7 +225,8 @@ namespace OniMcp.Server
             {
                 CleanupExpiredTasks();
                 McpTaskEntry task;
-                if (!_tasks.TryGetValue(@params.TaskId, out task))
+                if (!_tasks.TryGetValue(@params.TaskId, out task)
+                    || !string.Equals(task.SessionId, CurrentSessionId, StringComparison.Ordinal))
                 {
                     error = JsonRpcResponse.MakeError(request.Id, McpErrorCode.InvalidParams, $"Task not found: {@params.TaskId}");
                     return null;
@@ -238,6 +240,7 @@ namespace OniMcp.Server
             var task = new McpTaskEntry
             {
                 TaskId = Guid.NewGuid().ToString("N"),
+                SessionId = sessionId,
                 Status = "working",
                 StatusMessage = string.IsNullOrEmpty(callParams.Task.Title) ? $"Calling tool {callParams.Name}" : callParams.Task.Title,
                 CreatedAt = System.DateTime.UtcNow,
@@ -248,10 +251,15 @@ namespace OniMcp.Server
                 TtlMilliseconds = NormalizeTaskTtl(callParams.Task.Ttl)
             };
 
-            lock (_taskLock)
+            lock (_sessionLock)
             {
-                CleanupExpiredTasks();
-                _tasks[task.TaskId] = task;
+                if (!_running || !_sessions.ContainsKey(sessionId))
+                    throw new InvalidOperationException("Session not found or terminated");
+                lock (_taskLock)
+                {
+                    CleanupExpiredTasks();
+                    _tasks[task.TaskId] = task;
+                }
             }
 
             ExecuteToolTask(task.TaskId, callParams.Name, callParams.Arguments, sessionId);
@@ -262,6 +270,8 @@ namespace OniMcp.Server
         {
             MainThreadBridge.EnqueueDeferred(new System.Action(() =>
             {
+                if (!_running || !IsSessionActive(sessionId))
+                    return;
                 McpTaskEntry task;
                 lock (_taskLock)
                 {

--- a/mods/OniMcp/Server/McpHttpServerSettingsPage.cs
+++ b/mods/OniMcp/Server/McpHttpServerSettingsPage.cs
@@ -42,9 +42,8 @@ namespace OniMcp.Server
 
             try
             {
-                Dictionary<string, string> form;
-                using (var reader = new StreamReader(request.InputStream, request.ContentEncoding))
-                    form = ParseQueryString(reader.ReadToEnd());
+                var body = HttpRequestBody.Read(request.InputStream, request.ContentEncoding, request.ContentLength64, HttpRequestBody.MaxSettingsBytes);
+                var form = ParseQueryString(body);
 
                 var current = OniMcpOptions.Current;
                 string host = RequiredFormValue(form, "host");
@@ -78,6 +77,10 @@ namespace OniMcp.Server
                 SendHtml(response, RenderSettingsHtml(message, true), 200);
                 ScheduleSettingsRestartAfterResponse();
             }
+            catch (RequestBodyTooLargeException ex)
+            {
+                SendHtml(response, RenderSettingsHtml(ex.Message, false), 413);
+            }
             catch (Exception ex)
             {
                 SendHtml(response, RenderSettingsHtml("Error saving settings: " + ex.Message, false), 400);
@@ -90,11 +93,18 @@ namespace OniMcp.Server
             ThreadPool.QueueUserWorkItem(_ =>
             {
                 Thread.Sleep(250);
-                MainThreadBridge.EnqueueDeferred(() =>
+                try
                 {
-                    if (Instance != null)
-                        Instance.RestartServer();
-                });
+                    MainThreadBridge.EnqueueDeferred(() =>
+                    {
+                        if (Instance != null)
+                            Instance.RestartServer();
+                    });
+                }
+                catch (InvalidOperationException)
+                {
+                    // The game may destroy the bridge before this delayed callback runs.
+                }
             });
         }
 

--- a/mods/OniMcp/Server/McpHttpServerValidation.cs
+++ b/mods/OniMcp/Server/McpHttpServerValidation.cs
@@ -15,9 +15,11 @@ namespace OniMcp.Server
 {
         private bool IsSessionActive(string sessionId)
         {
+            if (string.IsNullOrEmpty(sessionId))
+                return false;
             lock (_sessionLock)
             {
-                return _sessions.ContainsKey(sessionId) && !_terminatedSessions.Contains(sessionId);
+                return _sessions.ContainsKey(sessionId);
             }
         }
 
@@ -32,13 +34,10 @@ namespace OniMcp.Server
             if (string.IsNullOrEmpty(sessionId))
                 return true;
 
-            lock (_sessionLock)
+            if (!IsSessionActive(sessionId))
             {
-                if (_terminatedSessions.Contains(sessionId))
-                {
-                    SendJson(response, JsonRpcResponse.MakeError(null, McpErrorCode.InvalidRequest, "Session not found or terminated"), 404);
-                    return false;
-                }
+                SendJson(response, JsonRpcResponse.MakeError(null, McpErrorCode.InvalidRequest, "Session not found or terminated"), 404);
+                return false;
             }
             return true;
         }
@@ -96,13 +95,11 @@ namespace OniMcp.Server
 
         private string EnsureSession(HttpListenerResponse response, string sessionId)
         {
-            if (string.IsNullOrEmpty(sessionId))
-                sessionId = Guid.NewGuid().ToString("N");
-
             lock (_sessionLock)
             {
-                if (!_sessions.ContainsKey(sessionId))
+                if (string.IsNullOrEmpty(sessionId))
                 {
+                    sessionId = Guid.NewGuid().ToString("N");
                     _sessions[sessionId] = new McpSession
                     {
                         Id = sessionId,
@@ -110,8 +107,17 @@ namespace OniMcp.Server
                         ProtocolVersion = CurrentProtocolVersion
                     };
                 }
+                else if (!_sessions.ContainsKey(sessionId))
+                {
+                    sessionId = null;
+                }
             }
 
+            if (sessionId == null)
+            {
+                SendJson(response, JsonRpcResponse.MakeError(null, McpErrorCode.InvalidRequest, "Session not found or terminated"), 404);
+                return null;
+            }
             response.Headers["Mcp-Session-Id"] = sessionId;
             return sessionId;
         }
@@ -209,21 +215,17 @@ namespace OniMcp.Server
         {
             var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             if (string.IsNullOrEmpty(query)) return result;
-            var pairs = query.Split('&');
+            var pairs = query.TrimStart('?').Split('&');
             foreach (var pair in pairs)
             {
-                var parts = pair.Split('=');
-                if (parts.Length == 2)
-                {
-                    string key = Uri.UnescapeDataString(parts[0]).Replace("+", " ");
-                    string val = Uri.UnescapeDataString(parts[1]).Replace("+", " ");
-                    result[key] = val;
-                }
-                else if (parts.Length == 1)
-                {
-                    string key = Uri.UnescapeDataString(parts[0]).Replace("+", " ");
-                    result[key] = "";
-                }
+                if (pair.Length == 0)
+                    continue;
+                int separator = pair.IndexOf('=');
+                string key = separator < 0 ? pair : pair.Substring(0, separator);
+                string value = separator < 0 ? "" : pair.Substring(separator + 1);
+                // Form '+' is a space; percent-encoded '+' and '=' are literal token characters.
+                result[Uri.UnescapeDataString(key.Replace("+", " "))] =
+                    Uri.UnescapeDataString(value.Replace("+", " "));
             }
             return result;
         }

--- a/mods/OniMcp/Server/McpHttpServerVirtualWorld.cs
+++ b/mods/OniMcp/Server/McpHttpServerVirtualWorld.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using Newtonsoft.Json;
@@ -52,7 +53,7 @@ namespace OniMcp.Server
                     while ((message = session.TryDequeueOutbound()) != null)
                         WriteSseMessage(response, message);
 
-                    session.OutboundSignal.WaitOne(15000);
+                    session.WaitForOutbound(15000);
                     if (_running && IsSessionActive(sessionId))
                         WriteSseComment(response, "keepalive");
                 }
@@ -65,9 +66,8 @@ namespace OniMcp.Server
             {
                 lock (_sessionLock)
                 {
-                    McpSession current;
-                    if (_sessions.TryGetValue(sessionId, out current) && current.SseConnections > 0)
-                        current.SseConnections--;
+                    if (session.SseConnections > 0)
+                        session.SseConnections--;
                 }
                 try { response.Close(); } catch { }
             }
@@ -83,10 +83,21 @@ namespace OniMcp.Server
         {
             lock (_sessionLock)
             {
-                if (_sessions.Remove(sessionId))
+                McpSession session;
+                if (_sessions.TryGetValue(sessionId, out session))
                 {
-                    sessionId = sessionId ?? "";
-                    _terminatedSessions.Add(sessionId);
+                    _sessions.Remove(sessionId);
+                    session.Close();
+                }
+            }
+            lock (_taskLock)
+            {
+                var taskIds = _tasks.Values.Where(task => task.SessionId == sessionId)
+                    .Select(task => task.TaskId).ToArray();
+                foreach (var taskId in taskIds)
+                {
+                    _tasks[taskId].CancelRequested = true;
+                    _tasks.Remove(taskId);
                 }
             }
             response.StatusCode = 204;
@@ -116,7 +127,7 @@ namespace OniMcp.Server
                 }
                 catch (Exception ex)
                 {
-                    rawHtml = $"<h1>Error serving page</h1><p>{ex.Message}</p>";
+                    rawHtml = $"<h1>Error serving page</h1><p>{WebUtility.HtmlEncode(ex.Message)}</p>";
                 }
                 SendHtml(response, rawHtml, 200);
                 return;

--- a/mods/OniMcp/Tools/Core/OniResourceRegistry.cs
+++ b/mods/OniMcp/Tools/Core/OniResourceRegistry.cs
@@ -28,12 +28,21 @@ namespace OniMcp.Tools
 
         public static ReadResourceResult ReadResource(string uri)
         {
-            if (string.IsNullOrEmpty(uri))
+            if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsed) || parsed.Scheme != "oni")
                 return null;
 
-            var resource = _resources.FirstOrDefault(item => item.Info.Uri == uri);
+            string resourceUri = parsed.GetLeftPart(UriPartial.Path).TrimEnd('/');
+            var resource = _resources.FirstOrDefault(item => item.Info.Uri.TrimEnd('/') == resourceUri);
             if (resource != null)
-                return ReadToolResource(uri, resource.ToolName, resource.Arguments != null ? new JObject(resource.Arguments) : new JObject(), resource.Info.MimeType);
+            {
+                var arguments = ParseQuery(parsed.Query);
+                if (resource.Arguments != null)
+                {
+                    foreach (var property in resource.Arguments.Properties())
+                        arguments[property.Name] = property.Value.DeepClone();
+                }
+                return ReadToolResource(uri, resource.ToolName, arguments, resource.Info.MimeType);
+            }
 
             return ReadDynamicResource(uri);
         }
@@ -63,14 +72,26 @@ namespace OniMcp.Tools
         private static ReadResourceResult ReadToolResource(string uri, string toolName, JObject arguments, string mimeType)
         {
             NormalizeResourceArguments(toolName, arguments);
-            var result = OniToolRegistry.CallTool(toolName, arguments);
+            if (!OniToolRegistry.TryGetOperation(toolName, out var operation))
+                return ErrorResource(uri, "Resource operation not found: " + toolName);
+
+            CallToolResult result;
+            try
+            {
+                // Resource routes select their read operation. resources/read has no
+                // tools/call task description and must not drain tool notifications.
+                result = operation.Handler(arguments ?? new JObject());
+            }
+            catch (Exception ex)
+            {
+                return ErrorResource(uri, "Resource operation error: " + ex.Message);
+            }
+
+            if (result == null)
+                return ErrorResource(uri, "Resource operation returned no result.");
             string text = ExtractText(result);
-            if (result != null && result.IsError)
-                text = JsonConvert.SerializeObject(new Dictionary<string, object>
-                {
-                    ["error"] = true,
-                    ["message"] = text
-                }, McpJsonUtil.Settings);
+            if (result.IsError)
+                return ErrorResource(uri, text);
 
             return new ReadResourceResult
             {
@@ -222,7 +243,7 @@ namespace OniMcp.Tools
             return string.Join("\n", result.Content.Where(content => content != null).Select(content => content.Text ?? "").ToArray());
         }
 
-        private static JObject ParseQuery(string query)
+        private static JObject ParseQuery(string query, bool allowOperationSelectors = false)
         {
             var result = new JObject();
             if (string.IsNullOrEmpty(query))
@@ -239,6 +260,13 @@ namespace OniMcp.Tools
                 if (string.IsNullOrEmpty(key))
                     continue;
 
+                // URI routes own operation selectors. Query strings supply filters;
+                // they cannot redirect a read to another domain or authorize writes.
+                if (key == "confirm" || key == "force" || (!allowOperationSelectors &&
+                    (key == "action" || key == "domain" || key == "uiDomain" ||
+                     key == "rocketDomain" || key == "bioDomain")))
+                    continue;
+
                 string value = parts.Length > 1 ? Uri.UnescapeDataString(parts[1]) : "";
                 if (string.IsNullOrEmpty(value))
                     continue;
@@ -249,30 +277,14 @@ namespace OniMcp.Tools
             return result;
         }
 
-        private static OniResource Resource(string uri, string name, string title, string description, string toolName)
+        private static OniResource Resource(string uri, string toolName, string title, string description, JObject arguments)
         {
             return new OniResource
             {
                 Info = new McpResourceInfo
                 {
                     Uri = uri,
-                    Name = name,
-                    Title = title,
-                    Description = description,
-                    MimeType = "application/json"
-                },
-                ToolName = toolName
-            };
-        }
-
-        private static OniResource Resource(string uri, string name, string title, string description, string toolName, JObject arguments)
-        {
-            return new OniResource
-            {
-                Info = new McpResourceInfo
-                {
-                    Uri = uri,
-                    Name = name,
+                    Name = toolName,
                     Title = title,
                     Description = description,
                     MimeType = "application/json"
@@ -291,132 +303,132 @@ namespace OniMcp.Tools
 
         private static readonly List<OniResource> _resources = new List<OniResource>
                 {
-                    Resource("oni://colony/status", "colony_control", "殖民地状态", "周期、复制人数、世界数量、速度和暂停状态。", "colony_control domain=read action=status", new JObject { ["domain"] = "read", ["action"] = "status" }),
-                    Resource("oni://colony/diagnostics", "colony_control", "殖民地诊断", "缺氧、断粮、过热等殖民地诊断结果。", "colony_control domain=diagnostic action=diagnostics", new JObject { ["domain"] = "diagnostic", ["action"] = "diagnostics" }),
-                    Resource("oni://colony/alerts", "colony_control", "殖民地警报", "当前游戏警报和通知。", "colony_control domain=diagnostic action=alerts", new JObject { ["domain"] = "diagnostic", ["action"] = "alerts" }),
-                    Resource("oni://colony/diagnostic-settings", "colony_control", "殖民地诊断设置", "AllDiagnosticsScreen 诊断显示模式、子条件启用状态和 Debug 通知禁用状态。", "colony_control domain=diagnostic action=list_settings", new JObject { ["domain"] = "diagnostic", ["action"] = "list_settings" }),
-                    Resource("oni://colony/report", "colony_control", "殖民地报告", "殖民地报告。", "colony_control domain=report action=report", new JObject { ["domain"] = "report", ["action"] = "report" }),
-                    Resource("oni://colony/summary", "colony_control", "殖民地摘要", "面向行动规划的殖民地摘要。", "colony_control domain=report action=summary", new JObject { ["domain"] = "report", ["action"] = "summary" }),
-                    Resource("oni://colony/notifications", "colony_control", "通知列表", "当前 HUD NotificationScreen/NotificationManager 通知、消息、聚焦目标和可清除状态。", "colony_control domain=notification action=list", new JObject { ["domain"] = "notification", ["action"] = "list" }),
-                    Resource("oni://world/list", "colony_control", "世界列表", "已加载世界和当前激活世界。", "colony_control domain=read action=worlds", new JObject { ["domain"] = "read", ["action"] = "worlds" }),
-                    Resource("oni://world/elements", "read_control", "世界元素摘要", "当前世界元素质量和温度摘要。", "read_control domain=world action=element_summary", new JObject { ["domain"] = "world", ["action"] = "element_summary" }),
-                    Resource("oni://camera/view", "navigation_control", "相机视图", "当前相机位置、缩放、激活世界和屏幕尺寸。", "navigation_control action=get_view", new JObject { ["action"] = "get_view" }),
-                    Resource("oni://resources/inventory", "read_control", "资源库存", "资源库存摘要。", "read_control domain=resources action=inventory", new JObject { ["domain"] = "resources", ["action"] = "inventory" }),
-                    Resource("oni://resources/food", "read_control", "食物库存", "食物库存和保质信息。", "read_control domain=resources action=food", new JObject { ["domain"] = "resources", ["action"] = "food" }),
-                    Resource("oni://resources/pins", "read_control", "资源面板固定和通知", "AllResourcesScreen 资源行固定显示和通知开关状态。", "read_control domain=resources action=pins", new JObject { ["domain"] = "resources", ["action"] = "pins" }),
-                    Resource("oni://diet/status", "colony_control", "饮食权限", "Consumables 管理屏中的复制人饮食/药品/电池可消费权限和库存。", "colony_control domain=management kind=diet action=status", new JObject { ["domain"] = "management", ["kind"] = "diet", ["action"] = "status" }),
-                    Resource("oni://storage/list", "building_control", "储存列表", "储存建筑和过滤器列表。", "building_control domain=storage action=list", new JObject { ["domain"] = "storage", ["action"] = "list" }),
-                    Resource("oni://storage/tile-selections", "building_control", "储存砖目标物品", "SingleItemSelectionSideScreen / StorageTile 目标物品和可选物品。", "building_control domain=tile_selection action=list", new JObject { ["domain"] = "tile_selection", ["action"] = "list" }),
-                    Resource("oni://filters/controls", "building_control", "过滤器控件", "气/液/固体单选过滤器、元素传感器和树形/平铺多选过滤器。", "building_control domain=filter action=list", new JObject { ["domain"] = "filter", ["action"] = "list" }),
-                    Resource("oni://controls/options", "building_control", "选项型侧屏控件", "工作方向、少量选项、逻辑广播频道和辐射粒子方向控件。", "building_control domain=side_surface surface=option action=list", new JObject { ["domain"] = "option", ["action"] = "list" }),
-                    Resource("oni://controls/state", "building_control", "状态型侧屏控件", "容量上限、单 checkbox、逻辑计数器和时间范围传感器控件。", "building_control action=state_list", new JObject { ["action"] = "state_list" }),
-                    Resource("oni://controls/activation-ranges", "building_control", "启停双阈值控件", "ActiveRangeSideScreen / IActivationRangeTarget 双阈值控件。", "building_control domain=side_surface surface=activation action=list", new JObject { ["domain"] = "activation", ["action"] = "list" }),
-                    Resource("oni://controls/progress-bars", "building_control", "侧屏进度条", "ProgressBarSideScreen / IProgressBarSideScreen 只读进度条状态。", "building_control domain=side_surface kind=progress action=list", new JObject { ["kind"] = "progress", ["action"] = "list" }),
-                    Resource("oni://controls/buttons", "building_control", "通用侧屏按钮", "实现 ISidescreenButtonControl 的通用侧屏按钮入口。", "building_control domain=side_surface kind=button action=list/press", new JObject { ["kind"] = "button", ["action"] = "list" }),
-                    Resource("oni://controls/user-menu-actions", "building_control", "对象用户菜单操作", "对象 UserMenu/context-menu 按钮映射：清扫、维修、堆肥、倒空、雕刻等非侧屏操作。", "building_control domain=side_surface surface=user_menu action=list", new JObject { ["domain"] = "user_menu", ["action"] = "list" }),
-                    Resource("oni://controls/maintenance-actions", "building_control", "维护类用户菜单操作", "需要状态机或槽位参数的玩家维护操作：厕所清洁、淡化器清空、运输管蜡、蜂巢清空、货仓倒空、复制人卸装。", "building_control domain=side_surface surface=maintenance action=list", new JObject { ["domain"] = "maintenance", ["action"] = "list" }),
-                    Resource("oni://controls/checklists", "building_control", "侧屏清单", "实现 ICheckboxListGroupControl 的故事任务、条件和设施清单。", "building_control domain=side_surface kind=checklist action=list", new JObject { ["kind"] = "checklist", ["action"] = "list" }),
-                    Resource("oni://controls/related-entities", "building_control", "关联对象", "实现 IRelatedEntities 的侧屏关联对象和可点击跳转目标。", "building_control domain=side_surface kind=related action=list/focus", new JObject { ["kind"] = "related", ["action"] = "list" }),
-                    Resource("oni://controls/n-toggles", "building_control", "多选侧屏控件", "实现 INToggleSideScreenControl 的多选侧屏控件。", "building_control domain=side_surface surface=misc kind=n_toggle action=list", new JObject { ["domain"] = "misc", ["kind"] = "n_toggle", ["action"] = "list" }),
-                    Resource("oni://automation/logic-alarms", "building_control", "逻辑报警器", "Logic Alarm 通知名称、提示、类型、暂停和镜头跳转设置。", "building_control domain=side_surface surface=misc kind=logic_alarm action=list", new JObject { ["domain"] = "misc", ["kind"] = "logic_alarm", ["action"] = "list" }),
-                    Resource("oni://automation/automatable", "building_control", "自动化专用搬运", "AutomatableSideScreen 只允许自动化/允许手动搬运状态。", "building_control domain=side_surface surface=automation kind=automatable action=list", new JObject { ["domain"] = "automation", ["kind"] = "automatable", ["action"] = "list" }),
-                    Resource("oni://automation/critter-sensors", "building_control", "小动物计数传感器", "CritterSensorSideScreen 小动物/蛋计数开关、阈值和当前计数。", "building_control domain=side_surface surface=automation kind=critter_sensor action=list", new JObject { ["domain"] = "automation", ["kind"] = "critter_sensor", ["action"] = "list" }),
-                    Resource("oni://automation/comet-detectors", "building_control", "彗星探测器", "Comet Detector/Space Scanner 当前探测目标和可选择目标。", "building_control domain=space_building kind=comet_detector action=list", new JObject { ["domain"] = "space_building", ["kind"] = "comet_detector", ["action"] = "list" }),
-                    Resource("oni://automation/cluster-location-sensors", "building_control", "星图位置传感器", "LogicClusterLocationSensor 空太空和星体/POI 坐标过滤设置。", "building_control domain=space_building kind=cluster_location_sensor action=list", new JObject { ["domain"] = "space_building", ["kind"] = "cluster_location_sensor", ["action"] = "list" }),
-                    Resource("oni://buildings/lights", "building_control", "灯光控件", "灯光建筑、发光参数和可选颜色预设。", "building_control action=visual kind=light visualAction=list", new JObject { ["action"] = "visual", ["kind"] = "light", ["visualAction"] = "list" }),
-                    Resource("oni://buildings/turbo-heaters", "building_control", "液体加热器涡轮模式", "Liquid Tepidizer TurboModeSideScreen 功耗和开关状态。", "building_control domain=side_surface surface=misc kind=turbo_heater action=list", new JObject { ["domain"] = "misc", ["kind"] = "turbo_heater", ["action"] = "list" }),
-                    Resource("oni://buildings/pixel-packs", "building_control", "Pixel Pack 控件", "Pixel Pack 当前逻辑值、四面板 active/standby 颜色和颜色预设。", "building_control action=visual kind=pixel_pack visualAction=list", new JObject { ["action"] = "visual", ["kind"] = "pixel_pack", ["visualAction"] = "list" }),
-                    Resource("oni://geotuners", "building_control", "GeoTuner", "GeoTuner 当前/未来目标喷泉和调谐分配状态。", "building_control domain=side_surface surface=geo_tuner action=list", new JObject { ["domain"] = "geo_tuner", ["action"] = "list" }),
-                    Resource("oni://geotuners/geysers", "building_control", "GeoTuner 喷泉目标", "GeoTuner 可选择喷泉、研究状态、可见性和分配数量。", "building_control domain=side_surface surface=geo_tuner action=list_geysers", new JObject { ["domain"] = "geo_tuner", ["action"] = "list_geysers" }),
-                    Resource("oni://buildings/artables", "building_control", "艺术建筑外观", "艺术建筑当前外观和可选择外观阶段。", "building_control domain=special kind=artable action=list", new JObject { ["domain"] = "special", ["kind"] = "artable", ["action"] = "list" }),
-                    Resource("oni://buildings/monument-parts", "building_control", "纪念碑部件外观", "纪念碑部件当前外观、可选外观和部件类型。", "building_control domain=special kind=monument_part action=list", new JObject { ["domain"] = "special", ["kind"] = "monument_part", ["action"] = "list" }),
-                    Resource("oni://ranching/lures", "building_control", "生物诱饵站", "生物诱饵站当前诱饵、可选诱饵和库存。", "building_control domain=special kind=creature_lure action=list", new JObject { ["domain"] = "special", ["kind"] = "creature_lure", ["action"] = "list" }),
-                    Resource("oni://buildings/gene-shufflers", "building_control", "Gene Shuffler", "Gene Shuffler 分配、工作完成、消耗和充能请求状态。", "building_control domain=special kind=gene_shuffler action=list", new JObject { ["domain"] = "special", ["kind"] = "gene_shuffler", ["action"] = "list" }),
-                    Resource("oni://story/printerceptors", "building_control", "Printerceptor", "Printerceptor passcode、拦截充能、打印界面和 databank 状态。", "building_control domain=story_facility kind=printerceptor action=list", new JObject { ["domain"] = "story_facility", ["kind"] = "printerceptor", ["action"] = "list" }),
-                    Resource("oni://story/poi-tech-unlocks", "building_control", "信息传送通道", "Research Portal/信息传送通道解锁差事、进度和 POI 科技项。", "building_control domain=story_facility kind=poi_tech_unlock action=list", new JObject { ["domain"] = "story_facility", ["kind"] = "poi_tech_unlock", ["action"] = "list" }),
-                    Resource("oni://buildings/remote-work-terminals", "building_control", "远程工作终端", "Remote Work Terminal 当前/未来 dock 和同世界可选 dock。", "building_control domain=story_facility kind=remote_work_terminal action=list", new JObject { ["domain"] = "story_facility", ["kind"] = "remote_work_terminal", ["action"] = "list" }),
-                    Resource("oni://farming/genetic-analysis-stations", "building_control", "Botanical Analyzer", "Botanical Analyzer 可分析种子、允许/禁用状态和库存。", "building_control domain=story_facility kind=genetic_analysis_station action=list", new JObject { ["domain"] = "story_facility", ["kind"] = "genetic_analysis_station", ["action"] = "list" }),
-                    Resource("oni://buildings/dispensers", "building_control", "分发器", "DispenserSideScreen 可分发物品、当前选择和分发请求状态。", "building_control domain=side_surface surface=facility kind=dispenser action=list", new JObject { ["domain"] = "facility", ["kind"] = "dispenser", ["action"] = "list" }),
-                    Resource("oni://buildings/receptacles", "building_control", "实体陈列/插槽", "ReceptacleSideScreen / SpecialCargoBayClusterSideScreen / SingleEntityReceptacle 通用实体请求、取消和移除状态。", "building_control domain=receptacle action=list", new JObject { ["domain"] = "receptacle", ["action"] = "list" }),
-                    Resource("oni://buildings/suit-lockers", "building_control", "太空服柜", "SuitLockerSideScreen 配置、请求、存储装备和掉落能力状态。", "building_control domain=side_surface surface=facility kind=suit_locker action=list", new JObject { ["domain"] = "facility", ["kind"] = "suit_locker", ["action"] = "list" }),
-                    Resource("oni://story/lore-bearers", "building_control", "LoreBearer", "LoreBearerSideScreen 可阅读/已阅读对象和按钮状态。", "building_control domain=side_surface surface=facility kind=lore_bearer action=list", new JObject { ["domain"] = "facility", ["kind"] = "lore_bearer", ["action"] = "list" }),
-                    Resource("oni://story/telepads", "building_control", "Printing Pod / Telepad", "TelepadSideScreen 移民、研究、技能提示和胜利条件状态。", "building_control domain=side_surface surface=facility kind=telepad action=list", new JObject { ["domain"] = "facility", ["kind"] = "telepad", ["action"] = "list" }),
-                    Resource("oni://story/artifacts", "building_control", "Artifact Analysis", "ArtifactAnalysisSideScreen 已分析 artifact、场上 artifact 和分析站状态。", "building_control domain=side_surface surface=facility kind=artifact action=list", new JObject { ["domain"] = "facility", ["kind"] = "artifact", ["action"] = "list" }),
-                    Resource("oni://story/warp-portals", "building_control", "Warp Portal", "WarpPortalSideScreen 等待传送、传送中、冷却和分配状态。", "building_control domain=space_story kind=warp_portal action=list", new JObject { ["domain"] = "space_story", ["kind"] = "warp_portal", ["action"] = "list" }),
-                    Resource("oni://story/temporal-tears", "building_control", "Temporal Tear", "TemporalTearSideScreen 裂隙开启、消耗状态和可进入火箭。", "building_control domain=space_story kind=temporal_tear action=list", new JObject { ["domain"] = "space_story", ["kind"] = "temporal_tear", ["action"] = "list" }),
-                    Resource("oni://space/telescopes", "building_control", "Telescope", "TelescopeSideScreen 建筑状态和当前星图分析目标。", "building_control domain=space_story kind=telescope action=list", new JObject { ["domain"] = "space_story", ["kind"] = "telescope", ["action"] = "list" }),
-                    Resource("oni://space/analysis-targets", "building_control", "星图分析目标", "星图目的地分析状态和可选择望远镜目标。", "building_control domain=space_story kind=starmap_analysis action=list", new JObject { ["domain"] = "space_story", ["kind"] = "starmap_analysis", ["action"] = "list" }),
-                    Resource("oni://diagnostics/process-conditions", "building_control", "通用过程条件", "ConditionListSideScreen/IProcessConditionSet 条件状态、文本和 tooltip。", "building_control domain=space_story kind=process_conditions action=list", new JObject { ["domain"] = "space_story", ["kind"] = "process_conditions", ["action"] = "list" }),
-                    Resource("oni://dupes/bionic-upgrades", "dupes_control", "仿生人升级槽", "BionicSideScreen 仿生人升级槽、分配和安装状态；写入使用 dupes_control domain=assignable action=set_slot。", "dupes_control domain=side_screen action=bionic_upgrades", new JObject { ["domain"] = "side_screen", ["action"] = "bionic_upgrades" }),
-                    Resource("oni://rockets/missile-launchers", "building_control", "导弹发射器", "导弹发射器弹药允许状态。", "building_control domain=special kind=missile_launcher action=list", new JObject { ["domain"] = "special", ["kind"] = "missile_launcher", ["action"] = "list" }),
-                    Resource("oni://rockets/modules", "building_control", "火箭模块", "火箭模块顺序、移除、替换和添加能力状态。", "building_control domain=rocket rocketDomain=module action=list", new JObject { ["domain"] = "module", ["action"] = "list" }),
-                    Resource("oni://rockets/module-defs", "building_control", "火箭模块定义", "SelectModuleSideScreen 可选择火箭模块定义和条件状态。", "building_control domain=rocket rocketDomain=module action=list_defs", new JObject { ["domain"] = "module", ["action"] = "list_defs" }),
-                    Resource("oni://rockets/launch-pads", "building_control", "火箭发射台", "LaunchPadSideScreen 发射台、已停靠火箭和可降落火箭。", "building_control domain=rocket rocketDomain=ops action=list_launch_pads", new JObject { ["domain"] = "ops", ["action"] = "list_launch_pads" }),
-                    Resource("oni://rockets/flight-utilities", "building_control", "火箭飞行模块实用操作", "ModuleFlightUtilitySideScreen 清空/投放、自动投放、目标和复制人选择状态。", "building_control domain=rocket rocketDomain=flight_utility action=list", new JObject { ["domain"] = "flight_utility", ["action"] = "list" }),
-                    Resource("oni://rockets/restrictions", "building_control", "火箭控制台限制", "RocketRestrictionSideScreen 地面/太空使用限制状态。", "building_control domain=rocket rocketDomain=restriction action=list", new JObject { ["domain"] = "restriction", ["action"] = "list" }),
-                    Resource("oni://rockets/usage-controls", "building_control", "火箭内部建筑使用限制", "火箭内部建筑是否受 RocketControlStation 限制的玩家菜单状态。", "building_control domain=rocket rocketDomain=usage action=list", new JObject { ["domain"] = "usage", ["action"] = "list" }),
-                    Resource("oni://rockets/crew-requests", "building_control", "火箭乘员召集", "SummonCrewSideScreen 乘员召集/释放状态、登船人数和驾驶员状态。", "building_control domain=rocket rocketDomain=crew_request action=list", new JObject { ["domain"] = "crew_request", ["action"] = "list" }),
-                    Resource("oni://rockets/assignment-groups", "building_control", "分配组成员", "AssignmentGroupControllerSideScreen 分配组成员状态和复制人成员开关。", "building_control domain=rocket rocketDomain=assignment_group action=list", new JObject { ["domain"] = "assignment_group", ["action"] = "list" }),
-                    Resource("oni://rockets/cargo-collectors", "building_control", "火箭货舱收集器", "CargoModuleSideScreen 星图货舱收集模块容量、库存和收集进度。", "building_control domain=rocket rocketDomain=cargo_status action=collectors", new JObject { ["domain"] = "cargo_status", ["action"] = "collectors" }),
-                    Resource("oni://rockets/harvest-modules", "building_control", "火箭钻探模块", "HarvestModuleSideScreen 太空钻探模块钻探状态和钻石库存。", "building_control domain=rocket rocketDomain=cargo_status action=harvest_modules", new JObject { ["domain"] = "cargo_status", ["action"] = "harvest_modules" }),
-                    Resource("oni://rockets/railguns", "building_control", "轨道炮", "轨道炮发射质量、库存和辐射粒子能量状态。", "building_control domain=space_building kind=railgun action=list", new JObject { ["domain"] = "space_building", ["kind"] = "railgun", ["action"] = "list" }),
-                    Resource("oni://rockets/self-destruct", "building_control", "火箭自毁", "SelfDestructButtonSideScreen 可自毁火箭舱体。", "building_control domain=rocket rocketDomain=self_destruct action=list", new JObject { ["domain"] = "self_destruct", ["action"] = "list" }),
-                    Resource("oni://buildings/defs", "building_control", "可建造建筑定义", "建造菜单建筑定义、分类、材料需求、可用外观和搜索结果。", "building_control action=search_defs", new JObject { ["action"] = "search_defs" }),
-                    Resource("oni://buildings/materials", "building_control", "可用建造材料", "指定建筑当前世界可用的合法建造材料，按库存排序；用于 material=auto 或显式材料选择。", "building_control action=materials", new JObject { ["action"] = "materials" }),
-                    Resource("oni://buildings/configurables", "building_control", "可配置建筑", "支持启用、开关、阈值、门状态、门禁和补料的建筑。", "building_control action=list", new JObject { ["action"] = "list" }),
-                    Resource("oni://automation/controls", "building_control", "自动化控件", "逻辑/电力相关玩家可配置控件：端口、开关、阈值、阀门、计时器、ribbon bit。", "building_control action=list_automation", new JObject { ["action"] = "list_automation" }),
-                    Resource("oni://production/fabricators", "building_control", "生产制作站", "制作站/精炼/厨房等配方队列、当前订单和运行状态。", "building_control domain=production action=list_fabricators", new JObject { ["domain"] = "production", ["action"] = "list_fabricators" }),
-                    Resource("oni://production/recipes", "building_control", "生产配方", "制作站 ComplexRecipe 配方、材料、产物、解锁和队列数量。", "building_control domain=production action=list_recipes", new JObject { ["domain"] = "production", ["action"] = "list_recipes" }),
-                    Resource("oni://production/mutant-seed-controls", "building_control", "突变种子接收开关", "制作站、鱼喂食器和香料研磨器的接受/拒收突变种子玩家菜单开关。", "building_control domain=production action=mutant_seed_list", new JObject { ["domain"] = "production", ["action"] = "mutant_seed_list" }),
-                    Resource("oni://production/configurable-consumers", "building_control", "可配置消费者", "ConfigureConsumerSideScreen 当前选项、可选项和消耗材料。", "building_control domain=side_surface surface=misc kind=configurable_consumer action=list", new JObject { ["domain"] = "misc", ["kind"] = "configurable_consumer", ["action"] = "list" }),
-                    Resource("oni://rockets/status", "building_control", "火箭状态", "Spaced Out 火箭和基础版航天器状态。", "building_control domain=rocket rocketDomain=ops action=status", new JObject { ["domain"] = "ops", ["action"] = "status" }),
-                    Resource("oni://research/status", "colony_control", "研究状态", "当前研究状态。", "colony_control domain=management kind=research action=status", new JObject { ["domain"] = "management", ["kind"] = "research", ["action"] = "status" }),
-                    Resource("oni://schedules", "colony_control", "日程", "复制人日程。", "colony_control domain=management kind=schedule action=list", new JObject { ["domain"] = "management", ["kind"] = "schedule", ["action"] = "list" }),
-                    Resource("oni://dupes", "colony_control", "复制人", "复制人列表和基本状态。", "colony_control domain=read action=dupes", new JObject { ["domain"] = "read", ["action"] = "dupes" }),
-                    Resource("oni://dupes/priorities", "dupes_control", "复制人个人优先级", "Priorities/Jobs 管理屏中复制人对各 ChoreGroup 的个人工作优先级。", "dupes_control domain=priority action=list", new JObject { ["domain"] = "priority", ["action"] = "list" }),
-                    Resource("oni://dupes/priority-settings", "dupes_control", "复制人优先级设置", "Jobs/Priorities 管理屏全局高级模式开关、默认重置行为和重置后优先级状态。", "dupes_control domain=priority action=settings_get", new JObject { ["domain"] = "priority", ["action"] = "settings_get" }),
-                    Resource("oni://dupes/skills", "dupes_control", "复制人技能", "Skills 管理屏中的复制人技能点、已学技能和可学习技能。", "dupes_control domain=skill action=list", new JObject { ["domain"] = "skill", ["action"] = "list" }),
-                    Resource("oni://dupes/hats", "dupes_control", "复制人帽子", "Skills 管理屏中的当前帽子、目标帽子和可选帽子列表。", "dupes_control domain=hat action=list", new JObject { ["domain"] = "hat", ["action"] = "list" }),
-                    Resource("oni://dupes/status-check", "dupes_control", "复制人状态检查", "复制人位置、当前差事、关键需求、周边可达格和疑似被困风险；只读。", "dupes_control domain=info action=status_check", new JObject { ["domain"] = "info", ["action"] = "status_check" }),
-                    Resource("oni://dupes/direct-commands", "dupes_control", "复制人直接命令", "复制人可直接执行/配置的玩家操作入口。", "dupes_control domain=side_screen action=direct_commands", new JObject { ["domain"] = "side_screen", ["action"] = "direct_commands" }),
-                    Resource("oni://dupes/todos", "dupes_control", "复制人待办差事", "MinionTodoSideScreen 当前差事、可执行差事和阻塞差事。", "dupes_control domain=side_screen action=todos", new JObject { ["domain"] = "side_screen", ["action"] = "todos" }),
-                    Resource("oni://dupes/equipment", "dupes_control", "复制人装备", "复制人装备槽、当前装备和可用装备分配对象；写入使用 dupes_control domain=assignable action=set_slot。", "dupes_control domain=side_screen action=equipment", new JObject { ["domain"] = "side_screen", ["action"] = "equipment" }),
-                    Resource("oni://assignables", "dupes_control", "可分配对象", "床、医疗床、餐桌、太空服等可分配对象和当前分配。", "dupes_control domain=assignable action=list", new JObject { ["domain"] = "assignable", ["action"] = "list" }),
-                    Resource("oni://farming/planting", "colony_control", "种植槽", "种植箱、农砖、当前植物、请求种子和可接受种子。", "colony_control domain=bio bioDomain=farming action=list_planting", new JObject { ["domain"] = "bio", ["bioDomain"] = "farming", ["action"] = "list_planting" }),
-                    Resource("oni://farming/harvestables", "colony_control", "可收获对象", "植物/作物的成熟、收获标记和成熟即收获状态。", "colony_control domain=bio bioDomain=farming action=list_harvestables", new JObject { ["domain"] = "bio", ["bioDomain"] = "farming", ["action"] = "list_harvestables" }),
-                    Resource("oni://farming/seeds", "colony_control", "种子目录", "可用于种植请求的 PlantableSeed prefab。", "colony_control domain=bio bioDomain=farming action=seed_catalog", new JObject { ["domain"] = "bio", ["bioDomain"] = "farming", ["action"] = "seed_catalog" }),
-                    Resource("oni://ranching/critters", "colony_control", "小动物", "可抓捕小动物、抓捕标记和捆绑状态。", "colony_control domain=bio bioDomain=ranching kind=critters action=critters", new JObject { ["domain"] = "bio", ["bioDomain"] = "ranching", ["kind"] = "critters", ["action"] = "critters" }),
-                    Resource("oni://ranching/dropoffs", "colony_control", "小动物投放点", "小动物/鱼类投放点过滤器、容量和计数。", "colony_control domain=bio bioDomain=ranching kind=dropoff action=list", new JObject { ["domain"] = "bio", ["bioDomain"] = "ranching", ["kind"] = "dropoff", ["action"] = "list" }),
-                    Resource("oni://ranching/incubators", "colony_control", "孵化器", "孵化器蛋请求、占用对象、进度和连续孵化设置。", "colony_control domain=bio bioDomain=ranching kind=incubator action=list", new JObject { ["domain"] = "bio", ["bioDomain"] = "ranching", ["kind"] = "incubator", ["action"] = "list" }),
-                    Resource("oni://medical/patients", "colony_control", "医疗患者", "需要医疗关注的复制人、疾病、生命值和医疗床分配。", "colony_control domain=management kind=medical action=patients", new JObject { ["domain"] = "management", ["kind"] = "medical", ["action"] = "patients" }),
-                    Resource("oni://medical/clinics", "colony_control", "医疗床和诊所", "医疗床/诊所治疗阈值、分配对象和优先级。", "colony_control domain=management kind=medical action=clinics", new JObject { ["domain"] = "management", ["kind"] = "medical", ["action"] = "clinics" }),
-                    Resource("oni://medical/doctor-stations", "colony_control", "医生站", "医生站药品库存和可治疗患者。", "colony_control domain=management kind=medical action=doctor_stations", new JObject { ["domain"] = "management", ["kind"] = "medical", ["action"] = "doctor_stations" }),
-                    Resource("oni://sandbox/actions", "game_control", "沙盒操作", "MCP 暴露的沙盒/Debug 操作、风险和当前沙盒状态。", "game_control domain=sandbox kind=read action=list_actions", new JObject { ["domain"] = "sandbox", ["kind"] = "read", ["action"] = "list_actions" }),
-                    Resource("oni://sandbox/story-traits", "game_control", "沙盒故事特质", "可由沙盒 Story Trait Tool 放置的故事特质模板。", "game_control domain=sandbox kind=read action=list_story_traits", new JObject { ["domain"] = "sandbox", ["kind"] = "read", ["action"] = "list_story_traits" }),
-                    Resource("oni://game/time", "game_control", "游戏时间和速度", "当前周期、时间百分比、暂停状态和速度。", "game_control domain=speed action=time", new JObject { ["domain"] = "speed", ["action"] = "time" }),
-                    Resource("oni://game/red-alert", "game_control", "红色警戒", "当前/全部世界红色警戒（紧急模式）状态。", "game_control domain=state action=red_alert_status", new JObject { ["domain"] = "state", ["action"] = "red_alert_status" }),
-                    Resource("oni://game/saves", "game_control", "存档文件", "本地/云端存档文件、当前 active save 和保存根目录。", "game_control domain=save action=list", new JObject { ["domain"] = "save", ["action"] = "list" }),
-                    Resource("oni://game/dlc", "game_control", "DLC 存档激活状态", "暂停菜单 DLC 激活按钮状态：订阅、当前存档启用、是否允许激活。", "game_control domain=dlc action=list", new JObject { ["domain"] = "dlc", ["action"] = "list" }),
-                    Resource("oni://mcp/sessions", "server_control", "MCP 会话", "当前 MCP session 和客户端 sampling、elicitation、tasks 能力。", "server_control domain=diagnostics action=capabilities", new JObject { ["domain"] = "diagnostics", ["action"] = "capabilities" }),
-                    Resource("oni://ui/actions", "game_control", "UI Action 白名单", "可安全触发的管理菜单、覆盖层、建造分类和导航 Action。", "game_control domain=ui uiDomain=action action=list", new JObject { ["domain"] = "ui", ["uiDomain"] = "action", ["action"] = "list" }),
-                    Resource("oni://tools/manifest", "server_control", "工具清单", "ONI MCP 工具目录。", "server_control domain=catalog action=manifest", new JObject { ["domain"] = "catalog", ["action"] = "manifest" }),
-                    Resource("oni://tools/guide", "server_control", "工具意图指南", "按玩家目标推荐资源、工具链和批量策略。", "server_control domain=catalog action=guide", new JObject { ["domain"] = "catalog", ["action"] = "guide" }),
-                    Resource("oni://tools/player-action-coverage", "server_control", "玩家操作覆盖审计", "玩家可执行操作面、对应 MCP 工具和缺口状态。", "server_control domain=catalog action=coverage", new JObject { ["domain"] = "catalog", ["action"] = "coverage" }),
-                    Resource("oni://tools/side-screen-surfaces", "server_control", "侧屏 surface 审计", "运行时 SideScreenContent 类型到 MCP 工具/资源覆盖的映射审计。", "server_control domain=catalog action=surface_audit surface=side_screen", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "side_screen" }),
-                    Resource("oni://tools/user-menu-surfaces", "server_control", "用户菜单 surface 审计", "源码 UserMenu/context-menu 按钮来源到 MCP 工具/资源覆盖的映射审计。", "server_control domain=catalog action=surface_audit surface=user_menu", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "user_menu" }),
-                    Resource("oni://tools/management-surfaces", "server_control", "管理界面 surface 审计", "源码 ManagementMenu/TableScreen/全屏管理界面到 MCP 工具/资源覆盖的映射审计。", "server_control domain=catalog action=surface_audit surface=management", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "management" }),
-                    Resource("oni://tools/tool-menu-surfaces", "server_control", "工具栏 surface 审计", "源码 ToolMenu 主工具栏/沙盒工具栏到 MCP 工具/资源覆盖的映射审计。", "server_control domain=catalog action=surface_audit surface=tool_menu", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "tool_menu" }),
-                    Resource("oni://tools/ui-menu-surfaces", "server_control", "UI 菜单 surface 审计", "源码 OverlayMenu/PlanScreen/BuildMenu/安全 UI hotkey 到 MCP 工具/资源覆盖的映射审计。", "server_control domain=catalog action=surface_audit surface=ui_menu", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "ui_menu" }),
-                    Resource("oni://tools/global-control-surfaces", "server_control", "全局控制 surface 审计", "源码 SpeedControlScreen/TopLeftControlScreen/PauseScreen/Options/Locker 到 MCP 覆盖的映射审计。", "server_control domain=catalog action=surface_audit surface=global_control", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "global_control" }),
-                    Resource("oni://tools/notification-surfaces", "server_control", "通知 surface 审计", "源码 NotificationScreen/NotificationManager/消息通知到 MCP 覆盖的映射审计。", "server_control domain=catalog action=surface_audit surface=notification", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "notification" }),
-                    Resource("oni://tools/static-audit", "server_control", "静态接口审计", "工具注册、玩家操作覆盖、资源入口和危险工具确认参数的静态自检。", "server_control domain=catalog action=static_audit", new JObject { ["domain"] = "catalog", ["action"] = "static_audit" }),
-                    Resource("oni://power/summary", "read_control", "电力摘要", "当前世界电力系统摘要：发电机额定功率、消费者负载、电池容量和电量，按 circuitId 聚合。", "read_control domain=infrastructure action=power_summary", new JObject { ["domain"] = "infrastructure", ["action"] = "power_summary" }),
-                    Resource("oni://power/ports", "read_control", "电力接口", "指定区域内建筑的电力接口格：锚点、输入/输出端口、相对偏移和可接线状态。", "read_control domain=infrastructure action=power_ports", new JObject { ["domain"] = "infrastructure", ["action"] = "power_ports" }),
-                    Resource("oni://rooms/list", "read_control", "房间列表", "房间系统状态：房间类型、大小、边界、对象计数和房间效果，适合检查士气房间是否成型。", "read_control domain=infrastructure action=rooms", new JObject { ["domain"] = "infrastructure", ["action"] = "rooms" }),
-                    Resource("oni://thermal/overheat-risk", "read_control", "过热风险扫描", "建筑过热风险扫描：按当前格温和建筑过热温度差排序，发现即将过热或已经过热的设备。", "read_control domain=world action=thermal_overheat_risk", new JObject { ["domain"] = "world", ["action"] = "thermal_overheat_risk" }),
-                    Resource("oni://world/search", "read_control", "地图搜索", "按 query/条件在地图上搜索元素格、建筑、散落物和复制人，支持区域过滤和最近排序。", "read_control domain=world action=search", new JObject { ["domain"] = "world", ["action"] = "search" }),
-                    Resource("oni://world/coordinate-screenshot", "navigation_control", "坐标截图", "保存带 ONI 世界坐标网格和坐标文本的截图，返回本地路径和 HTTP URL，适合视觉模型直接识别坐标。", "navigation_control action=coordinate_screenshot", new JObject { ["action"] = "coordinate_screenshot" }),
-                    Resource("oni://world/layout-candidates", "read_control", "平面布局候选", "按用途扫描区域，返回房间/平台候选矩形、评分、需挖掘、需铺砖、危险格和连通性。", "read_control domain=world action=layout_candidates", new JObject { ["domain"] = "world", ["action"] = "layout_candidates" })
+                    Resource("oni://colony/status", "colony_control", "殖民地状态", "周期、复制人数、世界数量、速度和暂停状态。", new JObject { ["domain"] = "read", ["action"] = "status" }),
+                    Resource("oni://colony/diagnostics", "colony_control", "殖民地诊断", "缺氧、断粮、过热等殖民地诊断结果。", new JObject { ["domain"] = "diagnostic", ["action"] = "diagnostics" }),
+                    Resource("oni://colony/alerts", "colony_control", "殖民地警报", "当前游戏警报和通知。", new JObject { ["domain"] = "diagnostic", ["action"] = "alerts" }),
+                    Resource("oni://colony/diagnostic-settings", "colony_control", "殖民地诊断设置", "AllDiagnosticsScreen 诊断显示模式、子条件启用状态和 Debug 通知禁用状态。", new JObject { ["domain"] = "diagnostic", ["action"] = "list_settings" }),
+                    Resource("oni://colony/report", "colony_control", "殖民地报告", "殖民地报告。", new JObject { ["domain"] = "report", ["action"] = "report" }),
+                    Resource("oni://colony/summary", "colony_control", "殖民地摘要", "面向行动规划的殖民地摘要。", new JObject { ["domain"] = "report", ["action"] = "summary" }),
+                    Resource("oni://colony/notifications", "colony_control", "通知列表", "当前 HUD NotificationScreen/NotificationManager 通知、消息、聚焦目标和可清除状态。", new JObject { ["domain"] = "notification", ["action"] = "list" }),
+                    Resource("oni://world/list", "colony_control", "世界列表", "已加载世界和当前激活世界。", new JObject { ["domain"] = "read", ["action"] = "worlds" }),
+                    Resource("oni://world/elements", "read_control", "世界元素摘要", "当前世界元素质量和温度摘要。", new JObject { ["domain"] = "world", ["action"] = "element_summary" }),
+                    Resource("oni://camera/view", "navigation_control", "相机视图", "当前相机位置、缩放、激活世界和屏幕尺寸。", new JObject { ["action"] = "get_view" }),
+                    Resource("oni://resources/inventory", "read_control", "资源库存", "资源库存摘要。", new JObject { ["domain"] = "resources", ["action"] = "inventory" }),
+                    Resource("oni://resources/food", "read_control", "食物库存", "食物库存和保质信息。", new JObject { ["domain"] = "resources", ["action"] = "food" }),
+                    Resource("oni://resources/pins", "read_control", "资源面板固定和通知", "AllResourcesScreen 资源行固定显示和通知开关状态。", new JObject { ["domain"] = "resources", ["action"] = "pins" }),
+                    Resource("oni://diet/status", "colony_control", "饮食权限", "Consumables 管理屏中的复制人饮食/药品/电池可消费权限和库存。", new JObject { ["domain"] = "management", ["kind"] = "diet", ["action"] = "status" }),
+                    Resource("oni://storage/list", "building_control", "储存列表", "储存建筑和过滤器列表。", new JObject { ["domain"] = "storage", ["action"] = "list" }),
+                    Resource("oni://storage/tile-selections", "building_control", "储存砖目标物品", "SingleItemSelectionSideScreen / StorageTile 目标物品和可选物品。", new JObject { ["domain"] = "tile_selection", ["action"] = "list" }),
+                    Resource("oni://filters/controls", "building_control", "过滤器控件", "气/液/固体单选过滤器、元素传感器和树形/平铺多选过滤器。", new JObject { ["domain"] = "filter", ["action"] = "list" }),
+                    Resource("oni://controls/options", "building_control", "选项型侧屏控件", "工作方向、少量选项、逻辑广播频道和辐射粒子方向控件。", new JObject { ["domain"] = "option", ["action"] = "list" }),
+                    Resource("oni://controls/state", "building_control", "状态型侧屏控件", "容量上限、单 checkbox、逻辑计数器和时间范围传感器控件。", new JObject { ["action"] = "state_list" }),
+                    Resource("oni://controls/activation-ranges", "building_control", "启停双阈值控件", "ActiveRangeSideScreen / IActivationRangeTarget 双阈值控件。", new JObject { ["domain"] = "activation", ["action"] = "list" }),
+                    Resource("oni://controls/progress-bars", "building_control", "侧屏进度条", "ProgressBarSideScreen / IProgressBarSideScreen 只读进度条状态。", new JObject { ["kind"] = "progress", ["action"] = "list" }),
+                    Resource("oni://controls/buttons", "building_control", "通用侧屏按钮", "实现 ISidescreenButtonControl 的通用侧屏按钮入口。", new JObject { ["kind"] = "button", ["action"] = "list" }),
+                    Resource("oni://controls/user-menu-actions", "building_control", "对象用户菜单操作", "对象 UserMenu/context-menu 按钮映射：清扫、维修、堆肥、倒空、雕刻等非侧屏操作。", new JObject { ["domain"] = "user_menu", ["action"] = "list" }),
+                    Resource("oni://controls/maintenance-actions", "building_control", "维护类用户菜单操作", "需要状态机或槽位参数的玩家维护操作：厕所清洁、淡化器清空、运输管蜡、蜂巢清空、货仓倒空、复制人卸装。", new JObject { ["domain"] = "maintenance", ["action"] = "list" }),
+                    Resource("oni://controls/checklists", "building_control", "侧屏清单", "实现 ICheckboxListGroupControl 的故事任务、条件和设施清单。", new JObject { ["kind"] = "checklist", ["action"] = "list" }),
+                    Resource("oni://controls/related-entities", "building_control", "关联对象", "实现 IRelatedEntities 的侧屏关联对象和可点击跳转目标。", new JObject { ["kind"] = "related", ["action"] = "list" }),
+                    Resource("oni://controls/n-toggles", "building_control", "多选侧屏控件", "实现 INToggleSideScreenControl 的多选侧屏控件。", new JObject { ["domain"] = "misc", ["kind"] = "n_toggle", ["action"] = "list" }),
+                    Resource("oni://automation/logic-alarms", "building_control", "逻辑报警器", "Logic Alarm 通知名称、提示、类型、暂停和镜头跳转设置。", new JObject { ["domain"] = "misc", ["kind"] = "logic_alarm", ["action"] = "list" }),
+                    Resource("oni://automation/automatable", "building_control", "自动化专用搬运", "AutomatableSideScreen 只允许自动化/允许手动搬运状态。", new JObject { ["domain"] = "automation", ["kind"] = "automatable", ["action"] = "list" }),
+                    Resource("oni://automation/critter-sensors", "building_control", "小动物计数传感器", "CritterSensorSideScreen 小动物/蛋计数开关、阈值和当前计数。", new JObject { ["domain"] = "automation", ["kind"] = "critter_sensor", ["action"] = "list" }),
+                    Resource("oni://automation/comet-detectors", "building_control", "彗星探测器", "Comet Detector/Space Scanner 当前探测目标和可选择目标。", new JObject { ["domain"] = "space_building", ["kind"] = "comet_detector", ["action"] = "list" }),
+                    Resource("oni://automation/cluster-location-sensors", "building_control", "星图位置传感器", "LogicClusterLocationSensor 空太空和星体/POI 坐标过滤设置。", new JObject { ["domain"] = "space_building", ["kind"] = "cluster_location_sensor", ["action"] = "list" }),
+                    Resource("oni://buildings/lights", "building_control", "灯光控件", "灯光建筑、发光参数和可选颜色预设。", new JObject { ["action"] = "visual", ["kind"] = "light", ["visualAction"] = "list" }),
+                    Resource("oni://buildings/turbo-heaters", "building_control", "液体加热器涡轮模式", "Liquid Tepidizer TurboModeSideScreen 功耗和开关状态。", new JObject { ["domain"] = "misc", ["kind"] = "turbo_heater", ["action"] = "list" }),
+                    Resource("oni://buildings/pixel-packs", "building_control", "Pixel Pack 控件", "Pixel Pack 当前逻辑值、四面板 active/standby 颜色和颜色预设。", new JObject { ["action"] = "visual", ["kind"] = "pixel_pack", ["visualAction"] = "list" }),
+                    Resource("oni://geotuners", "building_control", "GeoTuner", "GeoTuner 当前/未来目标喷泉和调谐分配状态。", new JObject { ["domain"] = "geo_tuner", ["action"] = "list" }),
+                    Resource("oni://geotuners/geysers", "building_control", "GeoTuner 喷泉目标", "GeoTuner 可选择喷泉、研究状态、可见性和分配数量。", new JObject { ["domain"] = "geo_tuner", ["action"] = "list_geysers" }),
+                    Resource("oni://buildings/artables", "building_control", "艺术建筑外观", "艺术建筑当前外观和可选择外观阶段。", new JObject { ["domain"] = "special", ["kind"] = "artable", ["action"] = "list" }),
+                    Resource("oni://buildings/monument-parts", "building_control", "纪念碑部件外观", "纪念碑部件当前外观、可选外观和部件类型。", new JObject { ["domain"] = "special", ["kind"] = "monument_part", ["action"] = "list" }),
+                    Resource("oni://ranching/lures", "building_control", "生物诱饵站", "生物诱饵站当前诱饵、可选诱饵和库存。", new JObject { ["domain"] = "special", ["kind"] = "creature_lure", ["action"] = "list" }),
+                    Resource("oni://buildings/gene-shufflers", "building_control", "Gene Shuffler", "Gene Shuffler 分配、工作完成、消耗和充能请求状态。", new JObject { ["domain"] = "special", ["kind"] = "gene_shuffler", ["action"] = "list" }),
+                    Resource("oni://story/printerceptors", "building_control", "Printerceptor", "Printerceptor passcode、拦截充能、打印界面和 databank 状态。", new JObject { ["domain"] = "story_facility", ["kind"] = "printerceptor", ["action"] = "list" }),
+                    Resource("oni://story/poi-tech-unlocks", "building_control", "信息传送通道", "Research Portal/信息传送通道解锁差事、进度和 POI 科技项。", new JObject { ["domain"] = "story_facility", ["kind"] = "poi_tech_unlock", ["action"] = "list" }),
+                    Resource("oni://buildings/remote-work-terminals", "building_control", "远程工作终端", "Remote Work Terminal 当前/未来 dock 和同世界可选 dock。", new JObject { ["domain"] = "story_facility", ["kind"] = "remote_work_terminal", ["action"] = "list" }),
+                    Resource("oni://farming/genetic-analysis-stations", "building_control", "Botanical Analyzer", "Botanical Analyzer 可分析种子、允许/禁用状态和库存。", new JObject { ["domain"] = "story_facility", ["kind"] = "genetic_analysis_station", ["action"] = "list" }),
+                    Resource("oni://buildings/dispensers", "building_control", "分发器", "DispenserSideScreen 可分发物品、当前选择和分发请求状态。", new JObject { ["domain"] = "facility", ["kind"] = "dispenser", ["action"] = "list" }),
+                    Resource("oni://buildings/receptacles", "building_control", "实体陈列/插槽", "ReceptacleSideScreen / SpecialCargoBayClusterSideScreen / SingleEntityReceptacle 通用实体请求、取消和移除状态。", new JObject { ["domain"] = "receptacle", ["action"] = "list" }),
+                    Resource("oni://buildings/suit-lockers", "building_control", "太空服柜", "SuitLockerSideScreen 配置、请求、存储装备和掉落能力状态。", new JObject { ["domain"] = "facility", ["kind"] = "suit_locker", ["action"] = "list" }),
+                    Resource("oni://story/lore-bearers", "building_control", "LoreBearer", "LoreBearerSideScreen 可阅读/已阅读对象和按钮状态。", new JObject { ["domain"] = "facility", ["kind"] = "lore_bearer", ["action"] = "list" }),
+                    Resource("oni://story/telepads", "building_control", "Printing Pod / Telepad", "TelepadSideScreen 移民、研究、技能提示和胜利条件状态。", new JObject { ["domain"] = "facility", ["kind"] = "telepad", ["action"] = "list" }),
+                    Resource("oni://story/artifacts", "building_control", "Artifact Analysis", "ArtifactAnalysisSideScreen 已分析 artifact、场上 artifact 和分析站状态。", new JObject { ["domain"] = "facility", ["kind"] = "artifact", ["action"] = "list" }),
+                    Resource("oni://story/warp-portals", "building_control", "Warp Portal", "WarpPortalSideScreen 等待传送、传送中、冷却和分配状态。", new JObject { ["domain"] = "space_story", ["kind"] = "warp_portal", ["action"] = "list" }),
+                    Resource("oni://story/temporal-tears", "building_control", "Temporal Tear", "TemporalTearSideScreen 裂隙开启、消耗状态和可进入火箭。", new JObject { ["domain"] = "space_story", ["kind"] = "temporal_tear", ["action"] = "list" }),
+                    Resource("oni://space/telescopes", "building_control", "Telescope", "TelescopeSideScreen 建筑状态和当前星图分析目标。", new JObject { ["domain"] = "space_story", ["kind"] = "telescope", ["action"] = "list" }),
+                    Resource("oni://space/analysis-targets", "building_control", "星图分析目标", "星图目的地分析状态和可选择望远镜目标。", new JObject { ["domain"] = "space_story", ["kind"] = "starmap_analysis", ["action"] = "list" }),
+                    Resource("oni://diagnostics/process-conditions", "building_control", "通用过程条件", "ConditionListSideScreen/IProcessConditionSet 条件状态、文本和 tooltip。", new JObject { ["domain"] = "space_story", ["kind"] = "process_conditions", ["action"] = "list" }),
+                    Resource("oni://dupes/bionic-upgrades", "dupes_control", "仿生人升级槽", "BionicSideScreen 仿生人升级槽、分配和安装状态；写入使用 dupes_control domain=assignable action=set_slot。", new JObject { ["domain"] = "side_screen", ["action"] = "bionic_upgrades" }),
+                    Resource("oni://rockets/missile-launchers", "building_control", "导弹发射器", "导弹发射器弹药允许状态。", new JObject { ["domain"] = "special", ["kind"] = "missile_launcher", ["action"] = "list" }),
+                    Resource("oni://rockets/modules", "building_control", "火箭模块", "火箭模块顺序、移除、替换和添加能力状态。", new JObject { ["domain"] = "module", ["action"] = "list" }),
+                    Resource("oni://rockets/module-defs", "building_control", "火箭模块定义", "SelectModuleSideScreen 可选择火箭模块定义和条件状态。", new JObject { ["domain"] = "module", ["action"] = "list_defs" }),
+                    Resource("oni://rockets/launch-pads", "building_control", "火箭发射台", "LaunchPadSideScreen 发射台、已停靠火箭和可降落火箭。", new JObject { ["domain"] = "ops", ["action"] = "list_launch_pads" }),
+                    Resource("oni://rockets/flight-utilities", "building_control", "火箭飞行模块实用操作", "ModuleFlightUtilitySideScreen 清空/投放、自动投放、目标和复制人选择状态。", new JObject { ["domain"] = "flight_utility", ["action"] = "list" }),
+                    Resource("oni://rockets/restrictions", "building_control", "火箭控制台限制", "RocketRestrictionSideScreen 地面/太空使用限制状态。", new JObject { ["domain"] = "restriction", ["action"] = "list" }),
+                    Resource("oni://rockets/usage-controls", "building_control", "火箭内部建筑使用限制", "火箭内部建筑是否受 RocketControlStation 限制的玩家菜单状态。", new JObject { ["domain"] = "usage", ["action"] = "list" }),
+                    Resource("oni://rockets/crew-requests", "building_control", "火箭乘员召集", "SummonCrewSideScreen 乘员召集/释放状态、登船人数和驾驶员状态。", new JObject { ["domain"] = "crew_request", ["action"] = "list" }),
+                    Resource("oni://rockets/assignment-groups", "building_control", "分配组成员", "AssignmentGroupControllerSideScreen 分配组成员状态和复制人成员开关。", new JObject { ["domain"] = "assignment_group", ["action"] = "list" }),
+                    Resource("oni://rockets/cargo-collectors", "building_control", "火箭货舱收集器", "CargoModuleSideScreen 星图货舱收集模块容量、库存和收集进度。", new JObject { ["domain"] = "cargo_status", ["action"] = "collectors" }),
+                    Resource("oni://rockets/harvest-modules", "building_control", "火箭钻探模块", "HarvestModuleSideScreen 太空钻探模块钻探状态和钻石库存。", new JObject { ["domain"] = "cargo_status", ["action"] = "harvest_modules" }),
+                    Resource("oni://rockets/railguns", "building_control", "轨道炮", "轨道炮发射质量、库存和辐射粒子能量状态。", new JObject { ["domain"] = "space_building", ["kind"] = "railgun", ["action"] = "list" }),
+                    Resource("oni://rockets/self-destruct", "building_control", "火箭自毁", "SelfDestructButtonSideScreen 可自毁火箭舱体。", new JObject { ["domain"] = "self_destruct", ["action"] = "list" }),
+                    Resource("oni://buildings/defs", "building_control", "可建造建筑定义", "建造菜单建筑定义、分类、材料需求、可用外观和搜索结果。", new JObject { ["action"] = "search_defs" }),
+                    Resource("oni://buildings/materials", "building_control", "可用建造材料", "指定建筑当前世界可用的合法建造材料，按库存排序；用于 material=auto 或显式材料选择。", new JObject { ["action"] = "materials" }),
+                    Resource("oni://buildings/configurables", "building_control", "可配置建筑", "支持启用、开关、阈值、门状态、门禁和补料的建筑。", new JObject { ["action"] = "list" }),
+                    Resource("oni://automation/controls", "building_control", "自动化控件", "逻辑/电力相关玩家可配置控件：端口、开关、阈值、阀门、计时器、ribbon bit。", new JObject { ["action"] = "list_automation" }),
+                    Resource("oni://production/fabricators", "building_control", "生产制作站", "制作站/精炼/厨房等配方队列、当前订单和运行状态。", new JObject { ["domain"] = "production", ["action"] = "list_fabricators" }),
+                    Resource("oni://production/recipes", "building_control", "生产配方", "制作站 ComplexRecipe 配方、材料、产物、解锁和队列数量。", new JObject { ["domain"] = "production", ["action"] = "list_recipes" }),
+                    Resource("oni://production/mutant-seed-controls", "building_control", "突变种子接收开关", "制作站、鱼喂食器和香料研磨器的接受/拒收突变种子玩家菜单开关。", new JObject { ["domain"] = "production", ["action"] = "mutant_seed_list" }),
+                    Resource("oni://production/configurable-consumers", "building_control", "可配置消费者", "ConfigureConsumerSideScreen 当前选项、可选项和消耗材料。", new JObject { ["domain"] = "misc", ["kind"] = "configurable_consumer", ["action"] = "list" }),
+                    Resource("oni://rockets/status", "building_control", "火箭状态", "Spaced Out 火箭和基础版航天器状态。", new JObject { ["domain"] = "ops", ["action"] = "status" }),
+                    Resource("oni://research/status", "colony_control", "研究状态", "当前研究状态。", new JObject { ["domain"] = "management", ["kind"] = "research", ["action"] = "status" }),
+                    Resource("oni://schedules", "colony_control", "日程", "复制人日程。", new JObject { ["domain"] = "management", ["kind"] = "schedule", ["action"] = "list" }),
+                    Resource("oni://dupes", "colony_control", "复制人", "复制人列表和基本状态。", new JObject { ["domain"] = "read", ["action"] = "dupes" }),
+                    Resource("oni://dupes/priorities", "dupes_control", "复制人个人优先级", "Priorities/Jobs 管理屏中复制人对各 ChoreGroup 的个人工作优先级。", new JObject { ["domain"] = "priority", ["action"] = "list" }),
+                    Resource("oni://dupes/priority-settings", "dupes_control", "复制人优先级设置", "Jobs/Priorities 管理屏全局高级模式开关、默认重置行为和重置后优先级状态。", new JObject { ["domain"] = "priority", ["action"] = "settings_get" }),
+                    Resource("oni://dupes/skills", "dupes_control", "复制人技能", "Skills 管理屏中的复制人技能点、已学技能和可学习技能。", new JObject { ["domain"] = "skill", ["action"] = "list" }),
+                    Resource("oni://dupes/hats", "dupes_control", "复制人帽子", "Skills 管理屏中的当前帽子、目标帽子和可选帽子列表。", new JObject { ["domain"] = "hat", ["action"] = "list" }),
+                    Resource("oni://dupes/status-check", "dupes_control", "复制人状态检查", "复制人位置、当前差事、关键需求、周边可达格和疑似被困风险；只读。", new JObject { ["domain"] = "info", ["action"] = "status_check" }),
+                    Resource("oni://dupes/direct-commands", "dupes_control", "复制人直接命令", "复制人可直接执行/配置的玩家操作入口。", new JObject { ["domain"] = "side_screen", ["action"] = "direct_commands" }),
+                    Resource("oni://dupes/todos", "dupes_control", "复制人待办差事", "MinionTodoSideScreen 当前差事、可执行差事和阻塞差事。", new JObject { ["domain"] = "side_screen", ["action"] = "todos" }),
+                    Resource("oni://dupes/equipment", "dupes_control", "复制人装备", "复制人装备槽、当前装备和可用装备分配对象；写入使用 dupes_control domain=assignable action=set_slot。", new JObject { ["domain"] = "side_screen", ["action"] = "equipment" }),
+                    Resource("oni://assignables", "dupes_control", "可分配对象", "床、医疗床、餐桌、太空服等可分配对象和当前分配。", new JObject { ["domain"] = "assignable", ["action"] = "list" }),
+                    Resource("oni://farming/planting", "colony_control", "种植槽", "种植箱、农砖、当前植物、请求种子和可接受种子。", new JObject { ["domain"] = "bio", ["bioDomain"] = "farming", ["action"] = "list_planting" }),
+                    Resource("oni://farming/harvestables", "colony_control", "可收获对象", "植物/作物的成熟、收获标记和成熟即收获状态。", new JObject { ["domain"] = "bio", ["bioDomain"] = "farming", ["action"] = "list_harvestables" }),
+                    Resource("oni://farming/seeds", "colony_control", "种子目录", "可用于种植请求的 PlantableSeed prefab。", new JObject { ["domain"] = "bio", ["bioDomain"] = "farming", ["action"] = "seed_catalog" }),
+                    Resource("oni://ranching/critters", "colony_control", "小动物", "可抓捕小动物、抓捕标记和捆绑状态。", new JObject { ["domain"] = "bio", ["bioDomain"] = "ranching", ["kind"] = "critters", ["action"] = "critters" }),
+                    Resource("oni://ranching/dropoffs", "colony_control", "小动物投放点", "小动物/鱼类投放点过滤器、容量和计数。", new JObject { ["domain"] = "bio", ["bioDomain"] = "ranching", ["kind"] = "dropoff", ["action"] = "list" }),
+                    Resource("oni://ranching/incubators", "colony_control", "孵化器", "孵化器蛋请求、占用对象、进度和连续孵化设置。", new JObject { ["domain"] = "bio", ["bioDomain"] = "ranching", ["kind"] = "incubator", ["action"] = "list" }),
+                    Resource("oni://medical/patients", "colony_control", "医疗患者", "需要医疗关注的复制人、疾病、生命值和医疗床分配。", new JObject { ["domain"] = "management", ["kind"] = "medical", ["action"] = "patients" }),
+                    Resource("oni://medical/clinics", "colony_control", "医疗床和诊所", "医疗床/诊所治疗阈值、分配对象和优先级。", new JObject { ["domain"] = "management", ["kind"] = "medical", ["action"] = "clinics" }),
+                    Resource("oni://medical/doctor-stations", "colony_control", "医生站", "医生站药品库存和可治疗患者。", new JObject { ["domain"] = "management", ["kind"] = "medical", ["action"] = "doctor_stations" }),
+                    Resource("oni://sandbox/actions", "game_control", "沙盒操作", "MCP 暴露的沙盒/Debug 操作、风险和当前沙盒状态。", new JObject { ["domain"] = "sandbox", ["kind"] = "read", ["action"] = "list_actions" }),
+                    Resource("oni://sandbox/story-traits", "game_control", "沙盒故事特质", "可由沙盒 Story Trait Tool 放置的故事特质模板。", new JObject { ["domain"] = "sandbox", ["kind"] = "read", ["action"] = "list_story_traits" }),
+                    Resource("oni://game/time", "game_control", "游戏时间和速度", "当前周期、时间百分比、暂停状态和速度。", new JObject { ["domain"] = "speed", ["action"] = "time" }),
+                    Resource("oni://game/red-alert", "game_control", "红色警戒", "当前/全部世界红色警戒（紧急模式）状态。", new JObject { ["domain"] = "state", ["action"] = "red_alert_status" }),
+                    Resource("oni://game/saves", "game_control", "存档文件", "本地/云端存档文件、当前 active save 和保存根目录。", new JObject { ["domain"] = "save", ["action"] = "list" }),
+                    Resource("oni://game/dlc", "game_control", "DLC 存档激活状态", "暂停菜单 DLC 激活按钮状态：订阅、当前存档启用、是否允许激活。", new JObject { ["domain"] = "dlc", ["action"] = "list" }),
+                    Resource("oni://mcp/sessions", "server_control", "MCP 会话", "当前 MCP session 和客户端 sampling、elicitation、tasks 能力。", new JObject { ["domain"] = "diagnostics", ["action"] = "capabilities" }),
+                    Resource("oni://ui/actions", "game_control", "UI Action 白名单", "可安全触发的管理菜单、覆盖层、建造分类和导航 Action。", new JObject { ["domain"] = "ui", ["uiDomain"] = "action", ["action"] = "list" }),
+                    Resource("oni://tools/manifest", "server_control", "工具清单", "ONI MCP 工具目录。", new JObject { ["domain"] = "catalog", ["action"] = "manifest" }),
+                    Resource("oni://tools/guide", "server_control", "工具意图指南", "按玩家目标推荐资源、工具链和批量策略。", new JObject { ["domain"] = "catalog", ["action"] = "guide" }),
+                    Resource("oni://tools/player-action-coverage", "server_control", "玩家操作覆盖审计", "玩家可执行操作面、对应 MCP 工具和缺口状态。", new JObject { ["domain"] = "catalog", ["action"] = "coverage" }),
+                    Resource("oni://tools/side-screen-surfaces", "server_control", "侧屏 surface 审计", "运行时 SideScreenContent 类型到 MCP 工具/资源覆盖的映射审计。", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "side_screen" }),
+                    Resource("oni://tools/user-menu-surfaces", "server_control", "用户菜单 surface 审计", "源码 UserMenu/context-menu 按钮来源到 MCP 工具/资源覆盖的映射审计。", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "user_menu" }),
+                    Resource("oni://tools/management-surfaces", "server_control", "管理界面 surface 审计", "源码 ManagementMenu/TableScreen/全屏管理界面到 MCP 工具/资源覆盖的映射审计。", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "management" }),
+                    Resource("oni://tools/tool-menu-surfaces", "server_control", "工具栏 surface 审计", "源码 ToolMenu 主工具栏/沙盒工具栏到 MCP 工具/资源覆盖的映射审计。", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "tool_menu" }),
+                    Resource("oni://tools/ui-menu-surfaces", "server_control", "UI 菜单 surface 审计", "源码 OverlayMenu/PlanScreen/BuildMenu/安全 UI hotkey 到 MCP 工具/资源覆盖的映射审计。", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "ui_menu" }),
+                    Resource("oni://tools/global-control-surfaces", "server_control", "全局控制 surface 审计", "源码 SpeedControlScreen/TopLeftControlScreen/PauseScreen/Options/Locker 到 MCP 覆盖的映射审计。", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "global_control" }),
+                    Resource("oni://tools/notification-surfaces", "server_control", "通知 surface 审计", "源码 NotificationScreen/NotificationManager/消息通知到 MCP 覆盖的映射审计。", new JObject { ["domain"] = "catalog", ["action"] = "surface_audit", ["surface"] = "notification" }),
+                    Resource("oni://tools/static-audit", "server_control", "静态接口审计", "工具注册、玩家操作覆盖、资源入口和危险工具确认参数的静态自检。", new JObject { ["domain"] = "catalog", ["action"] = "static_audit" }),
+                    Resource("oni://power/summary", "read_control", "电力摘要", "当前世界电力系统摘要：发电机额定功率、消费者负载、电池容量和电量，按 circuitId 聚合。", new JObject { ["domain"] = "infrastructure", ["action"] = "power_summary" }),
+                    Resource("oni://power/ports", "read_control", "电力接口", "指定区域内建筑的电力接口格：锚点、输入/输出端口、相对偏移和可接线状态。", new JObject { ["domain"] = "infrastructure", ["action"] = "power_ports" }),
+                    Resource("oni://rooms/list", "read_control", "房间列表", "房间系统状态：房间类型、大小、边界、对象计数和房间效果，适合检查士气房间是否成型。", new JObject { ["domain"] = "infrastructure", ["action"] = "rooms" }),
+                    Resource("oni://thermal/overheat-risk", "read_control", "过热风险扫描", "建筑过热风险扫描：按当前格温和建筑过热温度差排序，发现即将过热或已经过热的设备。", new JObject { ["domain"] = "world", ["action"] = "thermal_overheat_risk" }),
+                    Resource("oni://world/search", "read_control", "地图搜索", "按 query/条件在地图上搜索元素格、建筑、散落物和复制人，支持区域过滤和最近排序。", new JObject { ["domain"] = "world", ["action"] = "search" }),
+                    Resource("oni://world/coordinate-screenshot", "navigation_control", "坐标截图", "保存带 ONI 世界坐标网格和坐标文本的截图，返回本地路径和 HTTP URL，适合视觉模型直接识别坐标。", new JObject { ["action"] = "coordinate_screenshot" }),
+                    Resource("oni://world/layout-candidates", "read_control", "平面布局候选", "按用途扫描区域，返回房间/平台候选矩形、评分、需挖掘、需铺砖、危险格和连通性。", new JObject { ["domain"] = "world", ["action"] = "layout_candidates" })
                 };
 
                 private static readonly List<McpResourceTemplateInfo> _templates = BuildResourceTemplates();

--- a/mods/OniMcp/Tools/Core/OniResourceRegistryWorldAndColonyRoutes.cs
+++ b/mods/OniMcp/Tools/Core/OniResourceRegistryWorldAndColonyRoutes.cs
@@ -85,7 +85,7 @@ namespace OniMcp.Tools
                                             return ErrorResource(uri, "Tool not found: " + toolName);
                                         if (!string.Equals(tool.Mode, "read", StringComparison.OrdinalIgnoreCase))
                                             return ErrorResource(uri, "Only read tools can be exposed via oni://tools/read/{name}");
-                                        return ReadToolResource(uri, tool.Name, ParseQuery(parsed.Query), "application/json");
+                                        return ReadToolResource(uri, tool.Name, ParseQuery(parsed.Query, allowOperationSelectors: true), "application/json");
                                     }
                                 }
 

--- a/mods/OniMcp/Tools/Core/OniToolRegistry.cs
+++ b/mods/OniMcp/Tools/Core/OniToolRegistry.cs
@@ -37,7 +37,6 @@ namespace OniMcp.Tools
         public static void Initialize()
         {
             if (_initialized) return;
-            _initialized = true;
 
             Register(CoreToolEnglishDescriptions.Apply(ServerControlEntryTools.ControlServer()));
             Register(CoreToolEnglishDescriptions.Apply(WorldEditorTools.ControlWorldEditor()));
@@ -52,6 +51,7 @@ namespace OniMcp.Tools
             RegisterInternal(SearchControlTools.ControlSearch());
             RegisterInternal(CoordinateControlTools.ControlCoordinate());
             BuildToolInfoCache();
+            _initialized = true;
         }
 
         private static void Register(McpTool tool)
@@ -77,6 +77,9 @@ namespace OniMcp.Tools
 
         internal static bool TryGetOperation(string name, out McpTool operation)
         {
+            operation = null;
+            if (string.IsNullOrWhiteSpace(name))
+                return false;
             return TryGetTool(name, out operation) || _internalOperations.TryGetValue(name, out operation);
         }
 
@@ -110,12 +113,12 @@ namespace OniMcp.Tools
         {
             var cached = includeAll ? _cachedAllToolInfos : _cachedCoreToolInfos;
             if (cached != null)
-                return cached;
+                return new List<McpToolInfo>(cached);
 
             BuildToolInfoCache();
             cached = includeAll ? _cachedAllToolInfos : _cachedCoreToolInfos;
             if (cached != null)
-                return cached;
+                return new List<McpToolInfo>(cached);
 
             return BuildToolInfos(includeAll);
         }
@@ -195,6 +198,8 @@ namespace OniMcp.Tools
 
         internal static CallToolResult CallToolFromWorldEditor(string name, JObject arguments, bool allowValidatedCoordinates)
         {
+            if (string.IsNullOrWhiteSpace(name))
+                return CallToolResult.Error("Operation name is required.");
             if (_tools.ContainsKey(name) || _aliases.ContainsKey(name))
                 return CallToolCore(name, arguments, allowValidatedCoordinates);
             if (!_internalOperations.TryGetValue(name, out var operation))
@@ -228,6 +233,8 @@ namespace OniMcp.Tools
         private static CallToolResult CallToolCore(string name, JObject arguments, bool allowValidatedCoordinates)
         {
             var middlewareNotifications = ToolCallMiddleware.DrainNotifications();
+            if (string.IsNullOrWhiteSpace(name))
+                return ToolCallMiddleware.Inject(CallToolResult.Error("Tool name is required."), middlewareNotifications);
             bool usedLegacyAlias = false;
             if (!_tools.TryGetValue(name, out var tool))
             {
@@ -433,8 +440,6 @@ namespace OniMcp.Tools
             });
             return result;
         }
-
-
         private static string InferGroup(string name)
         {
             name = (name ?? "").ToLowerInvariant();

--- a/mods/OniMcp/Tools/Core/OniToolRegistryCache.cs
+++ b/mods/OniMcp/Tools/Core/OniToolRegistryCache.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,7 +7,6 @@ namespace OniMcp.Tools
     internal sealed class OniToolRegistryCache
     {
         private List<McpTool> allTools;
-        private List<McpTool> visibleTools;
 
         internal List<McpTool> GetTools(IEnumerable<McpTool> registeredTools)
         {
@@ -18,39 +18,35 @@ namespace OniMcp.Tools
             IEnumerable<McpTool> registeredTools,
             IEnumerable<McpTool> visibleRegisteredTools)
         {
-            Ensure(registeredTools, visibleRegisteredTools);
-            return new List<McpTool>(visibleTools.Where(tool => !tool.Hidden));
+            Ensure(registeredTools);
+            IEnumerable<McpTool> visible = allTools;
+            if (visibleRegisteredTools != null)
+                visible = Sort(visibleRegisteredTools);
+            return visible.Where(tool => !tool.Hidden).ToList();
         }
 
         internal List<McpTool> GetVisibleSnapshot()
         {
-            return visibleTools;
+            return allTools?.Where(tool => !tool.Hidden).ToList();
         }
 
         internal void Clear()
         {
             allTools = null;
-            visibleTools = null;
         }
 
         internal void Ensure(IEnumerable<McpTool> registeredTools)
         {
-            Ensure(registeredTools, null);
-        }
-
-        private void Ensure(
-            IEnumerable<McpTool> registeredTools,
-            IEnumerable<McpTool> visibleRegisteredTools)
-        {
-            if (allTools != null && visibleTools != null)
+            if (allTools != null)
                 return;
 
-            allTools = registeredTools
-                .OrderBy(tool => tool.Group)
-                .ThenBy(tool => tool.Name)
-                .ToList();
-            visibleTools = (visibleRegisteredTools ?? allTools.Where(tool => !tool.Hidden))
-                .ToList();
+            allTools = Sort(registeredTools).ToList();
+        }
+
+        private static IOrderedEnumerable<McpTool> Sort(IEnumerable<McpTool> tools)
+        {
+            return tools.OrderBy(tool => tool.Group, StringComparer.Ordinal)
+                .ThenBy(tool => tool.Name, StringComparer.Ordinal);
         }
     }
 }

--- a/mods/OniMcp/Tools/Core/ToolCallMiddleware.cs
+++ b/mods/OniMcp/Tools/Core/ToolCallMiddleware.cs
@@ -63,7 +63,8 @@ namespace OniMcp.Tools
 
         public static bool TryGetTaskDescription(JObject arguments, out string description)
         {
-            description = arguments?[TaskDescriptionParameter]?.ToString()?.Trim();
+            var token = arguments?[TaskDescriptionParameter];
+            description = token?.Type == JTokenType.String ? token.Value<string>()?.Trim() : null;
             return !string.IsNullOrWhiteSpace(description);
         }
 

--- a/mods/OniMcp/Tools/Impl/Server/AgentProgramExecutionRunner.cs
+++ b/mods/OniMcp/Tools/Impl/Server/AgentProgramExecutionRunner.cs
@@ -113,7 +113,7 @@ namespace OniMcp.Tools
                 return steps;
             }
 
-            private void ValidateBlock(JArray block, string path)
+            private void ValidateBlock(JArray block, string path, int loopDepth = 0)
             {
                 if (block == null)
                     throw new AgentProgramException(path + " must be an array");
@@ -122,26 +122,37 @@ namespace OniMcp.Tools
                     var stmt = block[i] as JObject;
                     if (stmt == null)
                         throw new AgentProgramException(path + "[" + i + "] must be an object");
-                    ValidateStatement(stmt, path + "[" + i + "]");
+                    ValidateStatement(stmt, path + "[" + i + "]", loopDepth);
                 }
             }
 
-            private void ValidateStatement(JObject stmt, string path)
+            private void ValidateStatement(JObject stmt, string path, int loopDepth)
             {
                 string op = Op(stmt);
                 if (op == "comment")
                     return;
-                if (op == "set" || op == "break" || op == "continue" || op == "return")
+                if (op == "break" || op == "continue")
+                {
+                    if (loopDepth == 0)
+                        throw new AgentProgramException(path + " " + op + " outside loop");
+                    return;
+                }
+                if (op == "set")
+                {
+                    ReadAssignments(stmt, path);
+                    return;
+                }
+                if (op == "return")
                     return;
 
                 if (op == "if")
                 {
                     if (ConditionToken(stmt) == null)
                         throw new AgentProgramException(path + " if requires when/condition/if");
-                    ValidateBlock(ThenBlock(stmt), path + ".then");
+                    ValidateBlock(ThenBlock(stmt), path + ".then", loopDepth);
                     var elseBlock = ElseBlock(stmt);
                     if (elseBlock != null)
-                        ValidateBlock(elseBlock, path + ".else");
+                        ValidateBlock(elseBlock, path + ".else", loopDepth);
                     return;
                 }
 
@@ -149,7 +160,7 @@ namespace OniMcp.Tools
                 {
                     if (ConditionToken(stmt) == null)
                         throw new AgentProgramException(path + " while requires when/condition/while");
-                    ValidateBlock(DoBlock(stmt), path + ".do");
+                    ValidateBlock(DoBlock(stmt), path + ".do", loopDepth + 1);
                     return;
                 }
 
@@ -157,7 +168,7 @@ namespace OniMcp.Tools
                 {
                     if (stmt["count"] == null && stmt["repeat"] == null)
                         throw new AgentProgramException(path + " repeat requires count");
-                    ValidateBlock(DoBlock(stmt), path + ".do");
+                    ValidateBlock(DoBlock(stmt), path + ".do", loopDepth + 1);
                     return;
                 }
 
@@ -243,14 +254,7 @@ namespace OniMcp.Tools
 
             private void ExecuteSet(JObject stmt, string path)
             {
-                var assignments = stmt["vars"] as JObject ?? stmt["set"] as JObject;
-                if (assignments == null && stmt["name"] != null)
-                {
-                    assignments = new JObject { [stmt["name"].ToString()] = stmt["value"] ?? JValue.CreateNull() };
-                }
-                if (assignments == null)
-                    throw new AgentProgramException(path + " set requires vars object or name/value");
-
+                var assignments = ReadAssignments(stmt, path);
                 var changed = new Dictionary<string, object>();
                 foreach (var property in assignments.Properties())
                 {
@@ -259,6 +263,19 @@ namespace OniMcp.Tools
                     changed[property.Name] = ToPlain(value);
                 }
                 Trace(path, "set", true, new Dictionary<string, object> { ["vars"] = changed });
+            }
+
+            private static JObject ReadAssignments(JObject stmt, string path)
+            {
+                var assignments = stmt["vars"] as JObject ?? stmt["set"] as JObject;
+                if (assignments == null && stmt["name"] != null)
+                {
+                    assignments = new JObject { [stmt["name"].ToString()] = stmt["value"] ?? JValue.CreateNull() };
+                }
+                if (assignments == null)
+                    throw new AgentProgramException(path + " set requires vars object or name/value");
+
+                return assignments;
             }
 
             private FlowSignal ExecuteIf(JObject stmt, string path)

--- a/mods/OniMcp/Tools/Impl/Server/AgentProgramExpressionRunner.cs
+++ b/mods/OniMcp/Tools/Impl/Server/AgentProgramExpressionRunner.cs
@@ -23,7 +23,10 @@ namespace OniMcp.Tools
                     toolName = stmt["tool"]?.ToString() ?? stmt["name"]?.ToString() ?? stmt["call"]?.ToString();
                     if (string.IsNullOrWhiteSpace(toolName))
                         throw new AgentProgramException("call requires tool/name");
-                    args = stmt["args"] as JObject ?? stmt["arguments"] as JObject ?? new JObject();
+                    var arguments = stmt["args"] ?? stmt["arguments"];
+                    if (arguments != null && arguments.Type != JTokenType.Object)
+                        throw new AgentProgramException("call args/arguments must be an object");
+                    args = (JObject)arguments ?? new JObject();
                     return true;
                 }
 
@@ -234,6 +237,8 @@ namespace OniMcp.Tools
                     else if (op == "mul") result *= next;
                     else if (op == "div") result /= next;
                     else if (op == "mod") result %= next;
+                    if (double.IsNaN(result) || double.IsInfinity(result))
+                        throw new AgentProgramException(op + " produced a non-finite numeric result");
                 }
                 if (Math.Abs(result - Math.Round(result)) < 0.000001 && result <= int.MaxValue && result >= int.MinValue)
                     return new JValue((int)Math.Round(result));

--- a/mods/OniMcp/Tools/Impl/Server/AgentProgramValueHelpers.cs
+++ b/mods/OniMcp/Tools/Impl/Server/AgentProgramValueHelpers.cs
@@ -47,9 +47,8 @@ namespace OniMcp.Tools
                 value = 0;
                 if (token == null || token.Type == JTokenType.Null)
                     return false;
-                if (token.Type == JTokenType.Integer || token.Type == JTokenType.Float)
-                    return double.TryParse(token.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out value);
-                return double.TryParse(token.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+                return double.TryParse(ToScalarString(token), NumberStyles.Float, CultureInfo.InvariantCulture, out value)
+                    && !double.IsNaN(value) && !double.IsInfinity(value);
             }
 
             private static double ToDouble(JToken token)
@@ -63,7 +62,9 @@ namespace OniMcp.Tools
             private static int ToInt(JToken token)
             {
                 double value = ToDouble(token);
-                return (int)Math.Round(value);
+                if (value < int.MinValue || value > int.MaxValue || value != Math.Truncate(value))
+                    throw new AgentProgramException("integer value required, got " + ToScalarString(token));
+                return (int)value;
             }
 
             private static bool ToBool(JToken token)
@@ -176,20 +177,27 @@ namespace OniMcp.Tools
 
             private static JArray ThenBlock(JObject stmt)
             {
-                return stmt["then"] as JArray ?? stmt["do"] as JArray ?? new JArray();
+                return ReadBlock(stmt["then"] ?? stmt["do"], "if then/do") ?? new JArray();
             }
 
             private static JArray ElseBlock(JObject stmt)
             {
-                return stmt["else"] as JArray;
+                return ReadBlock(stmt["else"], "if else");
             }
 
             private static JArray DoBlock(JObject stmt)
             {
-                var block = stmt["do"] as JArray ?? stmt["steps"] as JArray;
+                var block = ReadBlock(stmt["do"] ?? stmt["steps"], "loop do/steps");
                 if (block == null)
                     throw new AgentProgramException("loop requires do/steps array");
                 return block;
+            }
+
+            private static JArray ReadBlock(JToken token, string name)
+            {
+                if (token != null && token.Type != JTokenType.Array)
+                    throw new AgentProgramException(name + " must be an array");
+                return (JArray)token;
             }
         }
     }

--- a/mods/OniMcp/Tools/Impl/Server/ToolBatchTools.cs
+++ b/mods/OniMcp/Tools/Impl/Server/ToolBatchTools.cs
@@ -188,7 +188,8 @@ namespace OniMcp.Tools
                     ["results"] = results
                 };
 
-                    return CallToolResult.Text(JsonConvert.SerializeObject(payload, McpJsonUtil.Settings));
+                    string text = JsonConvert.SerializeObject(payload, McpJsonUtil.Settings);
+                    return failed == 0 ? CallToolResult.Text(text) : CallToolResult.Error(text);
                 }
             };
         }
@@ -270,7 +271,7 @@ namespace OniMcp.Tools
                 return new List<string>();
 
             return tool.Parameters
-                .Where(kv => kv.Value.Required && arguments[kv.Key] == null)
+                .Where(kv => kv.Value.Required && (arguments[kv.Key] == null || arguments[kv.Key].Type == JTokenType.Null))
                 .Select(kv => kv.Key)
                 .OrderBy(name => name)
                 .ToList();

--- a/mods/OniMcp/Tools/WorldEditor/WorldEditorMapEditTokenParsing.cs
+++ b/mods/OniMcp/Tools/WorldEditor/WorldEditorMapEditTokenParsing.cs
@@ -14,9 +14,9 @@ namespace OniMcp.Tools
             if (pattern == "?" || pattern == "*" || pattern == ".*")
                 return true;
             if (pattern.Length >= 2 && pattern[0] == '/' && pattern[pattern.Length - 1] == '/')
-                return Regex.IsMatch(actual ?? string.Empty, pattern.Substring(1, pattern.Length - 2));
+                return Regex.IsMatch(actual ?? string.Empty, pattern.Substring(1, pattern.Length - 2), RegexOptions.None, RegexMatchTimeout);
             if (pattern.StartsWith("~", StringComparison.Ordinal) && pattern.Length > 1)
-                return Regex.IsMatch(actual ?? string.Empty, pattern.Substring(1));
+                return Regex.IsMatch(actual ?? string.Empty, pattern.Substring(1), RegexOptions.None, RegexMatchTimeout);
             // Map rendering appends @(x,y) on the first cell of a building run.
             // Agents often strip that suffix when copying SEARCH tokens; treat both forms equal.
             string normalizedActual = NormalizeMapCompareToken(actual);

--- a/mods/OniMcp/Tools/WorldEditor/WorldEditorQueryTools.cs
+++ b/mods/OniMcp/Tools/WorldEditor/WorldEditorQueryTools.cs
@@ -10,6 +10,8 @@ namespace OniMcp.Tools
 {
     public static partial class WorldEditorTools
     {
+        private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromMilliseconds(100);
+
         private static CallToolResult Grep(JObject args)
         {
             string path = NormalizePath(Text(args, "path"), _cwd);
@@ -35,14 +37,21 @@ namespace OniMcp.Tools
                 return CallToolResult.Error(regexError);
             var hitLines = new SortedSet<int>();
 
-            for (int i = 0; i < lines.Length; i++)
+            try
             {
-                if (!matcher(lines[i]))
-                    continue;
-                for (int j = Math.Max(0, i - context); j <= Math.Min(lines.Length - 1, i + context); j++)
-                    hitLines.Add(j);
-                if (hitLines.Count >= limit)
-                    break;
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    if (!matcher(lines[i]))
+                        continue;
+                    for (int j = Math.Max(0, i - context); j <= Math.Min(lines.Length - 1, i + context); j++)
+                        hitLines.Add(j);
+                    if (hitLines.Count >= limit)
+                        break;
+                }
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                return CallToolResult.Error("regex match timed out; simplify the pattern or use regex=false");
             }
 
             var sb = new StringBuilder();
@@ -69,7 +78,7 @@ namespace OniMcp.Tools
                 var options = RegexOptions.CultureInvariant;
                 if (ignoreCase)
                     options |= RegexOptions.IgnoreCase;
-                var compiled = new Regex(query, options);
+                var compiled = new Regex(query, options, RegexMatchTimeout);
                 return line => compiled.IsMatch(line);
             }
             catch (ArgumentException ex)

--- a/scripts/check_mods.py
+++ b/scripts/check_mods.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Run Mod source contracts and executable regressions without installing ONI."""
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GAME_CHECKS = {
+    "verify_cycletrim_target_contract.py": "requires the installed game's Assembly-CSharp.dll and ilspycmd",
+    "verify_cycletrim_release_binary.py": "requires a built CycleTrim Release DLL and ilspycmd",
+    "verify_restart_packaging.py": "requires an OniMcp Debug build and distribution archive",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--static-only", action="store_true", help="run only Python source contracts")
+    parser.add_argument("--dotnet", default="dotnet", help=".NET 10 SDK executable name or path")
+    args = parser.parse_args()
+    checks = [
+        (path.name, [sys.executable, str(path)])
+        for path in sorted((ROOT / "scripts").glob("verify_*.py"))
+        if path.name not in GAME_CHECKS
+    ]
+    if not args.static_only:
+        dotnet = shutil.which(args.dotnet)
+        if dotnet is None:
+            parser.error(".NET 10 SDK was not found; install it or pass --dotnet PATH")
+        projects = sorted((ROOT / "tests").glob("*/*.csproj"))
+        if not projects:
+            parser.error("no Mod regression projects found under tests/")
+        projects.append(ROOT / "benchmarks/CycleTrim.BrainBenchmarks/CycleTrim.BrainBenchmarks.csproj")
+        checks.extend(
+            (str(path.relative_to(ROOT)), [dotnet, "run", "--project", str(path),
+                                         "--configuration", "Release",
+                                         "-p:ImportDirectoryBuildProps=false",
+                                         "-p:TreatWarningsAsErrors=true"])
+            for path in projects
+        )
+
+    failures = []
+    environment = dict(os.environ, DOTNET_CLI_TELEMETRY_OPTOUT="1",
+                       DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE="true")
+    for name, command in checks:
+        print(f"\nRUN {name}", flush=True)
+        try:
+            result = subprocess.run(command, cwd=ROOT, env=environment, check=False, timeout=300)
+            if result.returncode != 0:
+                failures.append(name)
+        except (OSError, subprocess.TimeoutExpired) as error:
+            print(f"FAIL {name}: {error}", file=sys.stderr)
+            failures.append(name)
+    for name, reason in GAME_CHECKS.items():
+        print(f"NOT RUN {name}: {reason}")
+    if args.static_only:
+        print("NOT RUN executable C# regressions (--static-only)")
+    print(f"\n{len(checks) - len(failures)}/{len(checks)} checks passed")
+    for name in failures:
+        print(f"FAIL {name}", file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/OniMcp.Config.Tests/OniMcp.Config.Tests.csproj
+++ b/tests/OniMcp.Config.Tests/OniMcp.Config.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <Compile Include="../../mods/OniMcp/Config/OniMcpOptions.cs" Link="OniMcpOptions.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Stubs.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/OniMcp.Config.Tests/Program.cs
+++ b/tests/OniMcp.Config.Tests/Program.cs
@@ -1,0 +1,182 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using OniMcp.Config;
+using OniMcp.Support;
+
+internal static class Program
+{
+    private static readonly FieldInfo CurrentField = typeof(OniMcpOptions)
+        .GetField("_current", BindingFlags.Static | BindingFlags.NonPublic);
+
+    private static void Main()
+    {
+        Run("missing config keeps authentication opt-in", MissingConfig);
+        Run("invalid initial config remains untouched and prevents startup", InvalidInitialConfig);
+        Run("unreadable initial config prevents startup", UnreadableInitialConfig);
+        Run("failed reload retains active authentication and original file", FailedReload);
+        Run("legacy config preserves authentication during migration", LegacyConfig);
+        Run("concurrent first access publishes a single configuration", ConcurrentInitialization);
+        Run("concurrent saves expose complete JSON to readers", AtomicSaves);
+        Run("failed save retains current configuration and cleans temporary files", FailedSave);
+        Console.WriteLine("PASS: 8 OniMcp config regression tests");
+    }
+
+    private static void Run(string name, Action test)
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "OniMcp.Config.Tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        OniMcpPaths.ConfigPath = Path.Combine(directory, "OniMcpConfig.json");
+        OniMcpPaths.ModPath = directory;
+        CurrentField.SetValue(null, null);
+        try
+        {
+            test();
+            Console.WriteLine("PASS: " + name);
+        }
+        finally
+        {
+            CurrentField.SetValue(null, null);
+            Directory.Delete(directory, true);
+        }
+    }
+
+    private static void MissingConfig()
+    {
+        var options = OniMcpOptions.Current;
+        Check(!options.AuthEnabled && options.Host == "localhost", "New installs must keep the existing defaults.");
+        Check(!string.IsNullOrEmpty(options.AuthToken), "New installs need a persistent token ready for opt-in.");
+        Check(JObject.Parse(File.ReadAllText(OniMcpPaths.ConfigPath))["AuthToken"].Value<string>() == options.AuthToken,
+            "The default token must be saved exactly once.");
+    }
+
+    private static void InvalidInitialConfig()
+    {
+        const string malformed = "{\"AuthEnabled\":true,\"AuthToken\":\"secret\"";
+        File.WriteAllText(OniMcpPaths.ConfigPath, malformed);
+        ExpectFailure(() => { var ignored = OniMcpOptions.Current; });
+        Check(File.ReadAllText(OniMcpPaths.ConfigPath) == malformed, "Failed reads must not destroy the original file.");
+        Check(CurrentField.GetValue(null) == null, "Invalid initial settings must not publish unauthenticated defaults.");
+    }
+
+    private static void UnreadableInitialConfig()
+    {
+        Directory.CreateDirectory(OniMcpPaths.ConfigPath);
+        ExpectFailure(() => { var ignored = OniMcpOptions.Current; });
+        Check(CurrentField.GetValue(null) == null, "A path that cannot be read must not publish defaults.");
+    }
+
+    private static void FailedReload()
+    {
+        var options = new OniMcpOptions { AuthEnabled = true, AuthToken = "retain-me", Port = 9234 };
+        OniMcpOptions.Save(options);
+        File.WriteAllText(OniMcpPaths.ConfigPath, "incomplete write");
+        OniMcpOptions.Reload();
+        Check(ReferenceEquals(options, OniMcpOptions.Current), "A failed reload must preserve active settings.");
+        Check(OniMcpOptions.Current.AuthEnabled && OniMcpOptions.Current.AuthToken == "retain-me", "Authentication changed.");
+        Check(File.ReadAllText(OniMcpPaths.ConfigPath) == "incomplete write", "Reload must leave the file available for recovery.");
+    }
+
+    private static void LegacyConfig()
+    {
+        File.WriteAllText(OniMcpPaths.ConfigPath, "{\"AuthEnabled\":true,\"AuthToken\":\" token \",\"Port\":99999}");
+        var options = OniMcpOptions.Current;
+        Check(options.AuthEnabled && options.AuthToken == "token", "Migration must retain opted-in authentication.");
+        Check(options.Port == 8788 && options.SecurityMigrationVersion == 1, "Migration and validation did not run.");
+        OniMcpOptions.Reload();
+        Check(OniMcpOptions.Current.AuthEnabled && OniMcpOptions.Current.AuthToken == "token", "Migrated settings did not persist.");
+    }
+
+    private static void ConcurrentInitialization()
+    {
+        var observed = new OniMcpOptions[16];
+        using (var start = new ManualResetEventSlim())
+        {
+            var threads = Enumerable.Range(0, observed.Length).Select(index => new Thread(() =>
+            {
+                start.Wait();
+                observed[index] = OniMcpOptions.Current;
+            })).ToArray();
+            foreach (var thread in threads)
+                thread.Start();
+            start.Set();
+            foreach (var thread in threads)
+                thread.Join();
+        }
+        Check(observed.All(options => ReferenceEquals(options, observed[0])), "Concurrent readers received different settings / tokens.");
+        Check(JObject.Parse(File.ReadAllText(OniMcpPaths.ConfigPath))["AuthToken"].Value<string>() == observed[0].AuthToken,
+            "The published token differs from the saved token.");
+    }
+
+    private static void AtomicSaves()
+    {
+        OniMcpOptions.Save(new OniMcpOptions());
+        using (var stop = new CancellationTokenSource())
+        using (var started = new ManualResetEventSlim())
+        {
+            int reads = 0;
+            var reader = Task.Run(() =>
+            {
+                do
+                {
+                    using (var stream = new FileStream(OniMcpPaths.ConfigPath, FileMode.Open, FileAccess.Read,
+                        FileShare.ReadWrite | FileShare.Delete))
+                    using (var text = new StreamReader(stream))
+                        JObject.Parse(text.ReadToEnd());
+                    Interlocked.Increment(ref reads);
+                    started.Set();
+                } while (!stop.IsCancellationRequested);
+            });
+            try
+            {
+                Check(started.Wait(TimeSpan.FromSeconds(10)), "The config reader did not start.");
+                Parallel.For(0, 100, index => OniMcpOptions.Save(new OniMcpOptions
+                {
+                    AuthEnabled = true,
+                    AuthToken = new string((char)('a' + index % 26), 32768),
+                    Port = 9000 + index
+                }));
+            }
+            finally
+            {
+                stop.Cancel();
+                reader.GetAwaiter().GetResult();
+            }
+            Check(reads > 1, "The test did not observe concurrent config reads.");
+            var saved = JObject.Parse(File.ReadAllText(OniMcpPaths.ConfigPath));
+            Check(saved["Port"].Value<int>() == OniMcpOptions.Current.Port, "Disk and active settings disagree.");
+        }
+        Check(!Directory.GetFiles(OniMcpPaths.ModPath, "*.tmp").Any(), "Successful saves left temporary files.");
+    }
+
+    private static void FailedSave()
+    {
+        var options = new OniMcpOptions { AuthEnabled = true, AuthToken = "keep-me" };
+        OniMcpOptions.Save(options);
+        string originalPath = OniMcpPaths.ConfigPath;
+        string original = File.ReadAllText(originalPath);
+        OniMcpPaths.ConfigPath = Path.Combine(OniMcpPaths.ModPath, "blocked");
+        Directory.CreateDirectory(OniMcpPaths.ConfigPath);
+        ExpectFailure(() => OniMcpOptions.Save(new OniMcpOptions { AuthEnabled = false }));
+        Check(ReferenceEquals(options, OniMcpOptions.Current), "A failed save replaced the active settings.");
+        Check(File.ReadAllText(originalPath) == original, "A failed save changed the previous file.");
+        Check(!Directory.GetFiles(OniMcpPaths.ModPath, "*.tmp").Any(), "A failed replacement left a temporary file.");
+    }
+
+    private static void ExpectFailure(Action action)
+    {
+        try { action(); }
+        catch (Exception ex) when (ex is InvalidOperationException || ex is IOException || ex is UnauthorizedAccessException) { return; }
+        throw new Exception("Expected the operation to fail.");
+    }
+
+    private static void Check(bool condition, string message)
+    {
+        if (!condition)
+            throw new Exception(message);
+    }
+}

--- a/tests/OniMcp.Config.Tests/Stubs.cs
+++ b/tests/OniMcp.Config.Tests/Stubs.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+
+// Only the game / PLib boundary is stubbed. Tests compile the production config code.
+namespace OniMcp.Support
+{
+    public static class OniMcpPaths
+    {
+        public static string ConfigPath { get; set; }
+        public static string ModPath { get; set; }
+    }
+
+    public static class OniMcpLog
+    {
+        public static void Warning(string message) { }
+        public static void Debug(string message) { }
+    }
+}
+
+namespace OniMcp.Server
+{
+    public sealed class McpHttpServer
+    {
+        public static McpHttpServer Instance { get; set; }
+        public void RestartServer() { }
+    }
+}
+
+namespace UnityEngine
+{
+    public static class Application
+    {
+        public static void OpenURL(string url) { }
+    }
+}
+
+namespace PeterHan.PLib.Options
+{
+    public interface IOptions
+    {
+        IEnumerable<IOptionsEntry> CreateOptions();
+        void OnOptionsChanged();
+    }
+
+    public interface IOptionsEntry { }
+
+    public sealed class ConfigFileAttribute : Attribute
+    {
+        public ConfigFileAttribute(string filename, bool shared) { }
+    }
+
+    public sealed class ModInfoAttribute : Attribute
+    {
+        public ModInfoAttribute(string url, string image) { }
+    }
+
+    public sealed class OptionAttribute : Attribute
+    {
+        public OptionAttribute(string title, string tooltip, string category) { }
+    }
+
+    public sealed class TextBlockOptionsEntry : IOptionsEntry
+    {
+        public TextBlockOptionsEntry(string name, OptionAttribute option) { }
+    }
+
+    public sealed class ButtonOptionsEntry : IOptionsEntry
+    {
+        public object Value { get; set; }
+        public ButtonOptionsEntry(string name, OptionAttribute option) { }
+    }
+}

--- a/tests/OniMcp.Core.Tests/GameStubs.cs
+++ b/tests/OniMcp.Core.Tests/GameStubs.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using OniMcp.Core;
+
+// Only game tool factories and the Unity overlay are replaced. Tests execute the
+// production registries, route tables, middleware and JSON-RPC serialization.
+namespace OniMcp.Tools
+{
+    internal static class GameStubs
+    {
+        internal static int HandlerCalls;
+        internal static bool FailNextFactory;
+
+        internal static McpTool Tool(string name)
+        {
+            if (FailNextFactory)
+            {
+                FailNextFactory = false;
+                throw new InvalidOperationException("factory failure");
+            }
+
+            return new McpTool
+            {
+                Name = name,
+                Mode = "execute",
+                Aliases = new List<string> { "legacy_" + name },
+                Parameters = new Dictionary<string, McpToolParameter>
+                {
+                    ["query"] = new McpToolParameter { Type = "string" }
+                },
+                Handler = arguments =>
+                {
+                    HandlerCalls++;
+                    if ((string)arguments["query"] == "throw")
+                        throw new InvalidOperationException("handler failure");
+                    if ((string)arguments["query"] == "error")
+                        return CallToolResult.Error("handler error");
+                    if ((string)arguments["query"] == "null")
+                        return null;
+                    return CallToolResult.Text(new JObject
+                    {
+                        ["tool"] = name,
+                        ["arguments"] = arguments.DeepClone()
+                    }.ToString());
+                }
+            };
+        }
+    }
+
+    internal static class ToolCallSpeechOverlay
+    {
+        internal static int Presentations;
+        internal static void ShowNearPlayerMouse(string description) { Presentations++; }
+        internal static void NotifyMissingDescription(string toolName) { }
+    }
+
+    internal static class CoreToolEnglishDescriptions { internal static McpTool Apply(McpTool tool) => tool; }
+    internal static class ServerControlEntryTools { internal static McpTool ControlServer() => GameStubs.Tool("server_control"); }
+    internal static class WorldEditorTools { internal static McpTool ControlWorldEditor() => GameStubs.Tool("world_editor"); }
+    internal static class NavigationControlTools { internal static McpTool ControlNavigation() => GameStubs.Tool("navigation_control"); }
+    internal static class BuildingControlTools { internal static McpTool ControlBuilding() => GameStubs.Tool("building_control"); }
+    internal static class GameControlEntryTools { internal static McpTool ControlGame() => GameStubs.Tool("game_control"); }
+    internal static class OrdersControlEntryTools { internal static McpTool ControlOrders() => GameStubs.Tool("orders_control"); }
+    internal static class BenchmarkTools { internal static McpTool Benchmark() => GameStubs.Tool("benchmark"); }
+    internal static class ColonyTools { internal static McpTool ControlColony() => GameStubs.Tool("colony_control"); }
+    internal static class DuplicantTools { internal static McpTool ControlDupes() => GameStubs.Tool("dupes_control"); }
+    internal static class ReadTools { internal static McpTool ControlRead() => GameStubs.Tool("read_control"); }
+    internal static class SearchControlTools { internal static McpTool ControlSearch() => GameStubs.Tool("search_control"); }
+    internal static class CoordinateControlTools { internal static McpTool ControlCoordinate() => GameStubs.Tool("coordinate_control"); }
+}

--- a/tests/OniMcp.Core.Tests/OniMcp.Core.Tests.csproj
+++ b/tests/OniMcp.Core.Tests/OniMcp.Core.Tests.csproj
@@ -1,0 +1,21 @@
+<Project>
+  <PropertyGroup>
+    <!-- The repository's optional Directory.Build.props validates a game install. -->
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <Compile Include="../../mods/OniMcp/Core/*.cs" Link="Production/Core/%(Filename)%(Extension)" />
+    <Compile Include="../../mods/OniMcp/Support/McpJsonUtil.cs" Link="Production/McpJsonUtil.cs" />
+    <Compile Include="../../mods/OniMcp/Tools/Core/*.cs" Link="Production/Tools/%(Filename)%(Extension)" />
+  </ItemGroup>
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/tests/OniMcp.Core.Tests/Program.cs
+++ b/tests/OniMcp.Core.Tests/Program.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OniMcp.Core;
+using OniMcp.Support;
+using OniMcp.Tools;
+
+internal static class Program
+{
+    private static int failures;
+
+    private static int Main()
+    {
+        Run("registry initialization can retry after a factory failure", InitializationRetry);
+        Run("JSON-RPC preserves null id and success result", JsonRpcNulls);
+        Run("task descriptions require nonempty JSON strings", TaskDescriptions);
+        Run("invalid tool names return errors", InvalidNames);
+        Run("tool calls still enforce coordinate and task constraints", ToolConstraints);
+        Run("tool cache respects visibility after all-tools access", CacheVisibility);
+        Run("metadata list callers cannot corrupt cached tool count", MetadataIsolation);
+        Run("all static resources dispatch to their registered operation", StaticResources);
+        Run("dynamic resource routes preserve their read action", DynamicResources);
+        Run("resource templates reject query operation overrides", TemplateConstraints);
+        Run("resource errors return valid JSON content", ResourceErrors);
+        Console.WriteLine(failures == 0 ? "All 11 core regression groups passed." : failures + " regression groups failed.");
+        return failures == 0 ? 0 : 1;
+    }
+
+    private static void Run(string name, Action test)
+    {
+        try
+        {
+            ToolCallMiddleware.Clear();
+            test();
+            Console.WriteLine("PASS " + name);
+        }
+        catch (Exception ex)
+        {
+            failures++;
+            Console.Error.WriteLine("FAIL " + name + ": " + ex.Message);
+        }
+    }
+
+    private static void Require(bool condition, string message)
+    {
+        if (!condition)
+            throw new InvalidOperationException(message);
+    }
+
+    private static void InitializationRetry()
+    {
+        GameStubs.FailNextFactory = true;
+        try
+        {
+            OniToolRegistry.Initialize();
+            throw new Exception("Expected a factory failure.");
+        }
+        catch (InvalidOperationException) { }
+        OniToolRegistry.Initialize();
+        Require(OniToolRegistry.GetTools().Count == 7, "Retry left the public registry incomplete.");
+        Require(OniToolRegistry.TryGetOperation("read_control", out _), "Retry did not initialize internal operations.");
+    }
+
+    private static void JsonRpcNulls()
+    {
+        var error = Serialize(JsonRpcResponse.MakeError(null, McpErrorCode.ParseError, "invalid JSON"));
+        Require(error.Property("id") != null && error["id"].Type == JTokenType.Null, "Error omitted id:null.");
+        Require(error.Property("result") == null && error["error"] != null, "Error must contain only the error branch.");
+        var success = Serialize(JsonRpcResponse.Success(null, null));
+        Require(success.Property("id") != null && success["id"].Type == JTokenType.Null, "Success omitted id:null.");
+        Require(success.Property("result") != null && success["result"].Type == JTokenType.Null, "Success omitted result:null.");
+        Require(success.Property("error") == null, "Success unexpectedly contains error.");
+        Require((int)Serialize(JsonRpcResponse.Success(4, false))["id"] == 4, "Numeric id changed.");
+    }
+
+    private static JObject Serialize(object value) => JObject.Parse(JsonConvert.SerializeObject(value, McpJsonUtil.Settings));
+
+    private static void TaskDescriptions()
+    {
+        foreach (var value in new JToken[] { JValue.CreateNull(), new JValue(42), new JValue(true), new JObject(), new JArray("x"), new JValue("  ") })
+        {
+            var args = new JObject { ["task"] = value };
+            Require(!ToolCallMiddleware.TryGetTaskDescription(args, out _), "Accepted task type " + value.Type);
+            int calls = GameStubs.HandlerCalls;
+            Require(OniToolRegistry.CallTool("game_control", args).IsError, "Invalid task reached dispatch.");
+            Require(calls == GameStubs.HandlerCalls, "Invalid task executed the handler.");
+        }
+        Require(!ToolCallMiddleware.TryGetTaskDescription(null, out _), "Accepted missing arguments.");
+        Require(ToolCallMiddleware.TryGetTaskDescription(new JObject { ["task"] = "  inspect oxygen  " }, out var text)
+            && text == "inspect oxygen", "Valid task was not trimmed.");
+    }
+
+    private static void InvalidNames()
+    {
+        foreach (var name in new[] { null, "", " ", "missing" })
+        {
+            Require(!OniToolRegistry.TryGetOperation(name, out _), "Invalid operation resolved.");
+            Require(OniToolRegistry.CallTool(name, new JObject()).IsError, "Invalid public name did not return an error.");
+            Require(OniToolRegistry.CallToolFromWorldEditor(name, new JObject(), false).IsError, "Invalid internal name did not return an error.");
+        }
+    }
+
+    private static void ToolConstraints()
+    {
+        Require(OniToolRegistry.CallTool("game_control", new JObject()).IsError, "Task requirement was lost.");
+        Require(OniToolRegistry.CallTool("game_control", new JObject
+        {
+            ["task"] = "inspect",
+            ["target"] = new JObject { ["x"] = 4 }
+        }).IsError, "Nested coordinates escaped validation.");
+        Require(!OniToolRegistry.CallTool("legacy_game_control", new JObject { ["task"] = "inspect" }).IsError, "Alias dispatch failed.");
+    }
+
+    private static void CacheVisibility()
+    {
+        var a = new McpTool { Name = "a", Group = "one", Hidden = true };
+        var b = new McpTool { Name = "b", Group = "one" };
+        var c = new McpTool { Name = "c", Group = "one" };
+        var tools = new[] { c, b, a };
+        var cache = new OniToolRegistryCache();
+        var all = cache.GetTools(tools);
+        Require(all.Select(tool => tool.Name).SequenceEqual(new[] { "a", "b", "c" }), "All-tools order is unstable.");
+        Require(cache.GetVisibleTools(tools, new[] { c }).Single() == c, "Previously cached all-tools ignored the supplied visible subset.");
+        a.Hidden = false;
+        Require(cache.GetVisibleSnapshot().Count == 3, "Visibility changes were retained in a stale snapshot.");
+        all.Clear();
+        cache.GetVisibleSnapshot().Clear();
+        Require(cache.GetTools(tools).Count == 3, "Caller modified cached membership.");
+        cache.Clear();
+        Require(cache.GetTools(new[] { b }).Count == 1, "Clear did not invalidate the cache.");
+    }
+
+    private static void MetadataIsolation()
+    {
+        int count = OniToolRegistry.GetToolInfos().Count;
+        OniToolRegistry.GetToolInfos().Clear();
+        Require(count > 0 && OniToolRegistry.GetToolInfos().Count == count, "Caller removed cached metadata entries.");
+    }
+
+    private static JObject Read(string uri)
+    {
+        var resource = OniResourceRegistry.ReadResource(uri);
+        Require(resource?.Contents?.Count == 1, "Missing resource content: " + uri);
+        return JObject.Parse(resource.Contents[0].Text);
+    }
+
+    private static void StaticResources()
+    {
+        var resources = OniResourceRegistry.GetResourceInfos();
+        Require(resources.Count > 0, "No resource routes registered.");
+        ToolCallMiddleware.QueueNotification("next tool call");
+        int presentations = ToolCallSpeechOverlay.Presentations;
+        foreach (var resource in resources)
+        {
+            var result = Read(resource.Uri);
+            Require(result["error"] == null, resource.Uri + ": " + (string)result["message"]);
+            Require((string)result["tool"] == resource.Name, "Wrong operation for " + resource.Uri);
+            Require(!string.IsNullOrEmpty((string)result["arguments"]["action"]), "Missing read action for " + resource.Uri);
+        }
+        Require((int)ToolCallMiddleware.Status()["pendingNotifications"] == 1, "Resource reads consumed tool notifications.");
+        Require(ToolCallSpeechOverlay.Presentations == presentations, "Resource reads displayed tool-call overlays.");
+        Require(OniResourceRegistry.ReadResource("oni://missing/resource") == null, "Unknown URI should remain unresolved.");
+    }
+
+    private static void DynamicResources()
+    {
+        var summary = Read("oni://power/summary?query=ore%20pile&action=delete&domain=invalid");
+        Require((string)summary["tool"] == "read_control", "Internal read operation was not found.");
+        Require((string)summary["arguments"]["action"] == "power_summary", "Query overrode the resource read action.");
+        Require((string)summary["arguments"]["domain"] == "infrastructure", "Query overrode the resource domain.");
+        Require((string)summary["arguments"]["query"] == "ore pile", "Query decoding failed.");
+        var cell = Read("oni://world/cell/4/5");
+        Require((string)cell["arguments"]["action"] == "cell_info" && (int)cell["arguments"]["x"] == 4, "World cell route failed.");
+        var sandbox = Read("oni://sandbox/cell/6/7");
+        Require((string)sandbox["arguments"]["kind"] == "read" && (string)sandbox["arguments"]["action"] == "sample_cell", "Sandbox sampling route changed operation.");
+    }
+
+    private static void ResourceErrors()
+    {
+        foreach (var query in new[] { "throw", "error", "null" })
+        {
+            var resource = OniResourceRegistry.ReadResource("oni://world/text-map?query=" + query);
+            Require(resource.Contents[0].MimeType == "application/json", "Error has a non-JSON MIME type.");
+            Require((bool)JObject.Parse(resource.Contents[0].Text)["error"], "Resource failure did not become an error response.");
+        }
+    }
+
+    private static void TemplateConstraints()
+    {
+        int checkedRoutes = 0;
+        foreach (var template in OniResourceRegistry.GetResourceTemplateInfos())
+        {
+            string uri = Regex.Replace(template.UriTemplate, @"\{\?[^}]*\}", "");
+            uri = Regex.Replace(uri, @"\{[^}]+\}", "1");
+            var baseline = OniResourceRegistry.ReadResource(uri + "?limit=1");
+            if (baseline == null)
+                throw new InvalidOperationException("Unresolved resource template: " + template.UriTemplate);
+            var result = JObject.Parse(baseline.Contents[0].Text);
+            if (result["error"] != null)
+                continue; // Explicitly disabled routes and unknown generic tool names.
+            var poisoned = Read(uri + "?action=delete&domain=sandbox&uiDomain=debug&rocketDomain=self_destruct&bioDomain=delete&confirm=true&force=true");
+            foreach (var key in new[] { "action", "domain", "uiDomain", "rocketDomain", "bioDomain", "confirm", "force" })
+                Require(JToken.DeepEquals(result["arguments"][key], poisoned["arguments"]?[key]), "Query overrode " + key + " at " + uri);
+            checkedRoutes++;
+        }
+        Require(checkedRoutes > 50, "Insufficient resource-template coverage.");
+        Require((bool)Read("oni://tools/read/game_control?action=delete")["error"], "Generic read route accepted an execute tool.");
+        Console.WriteLine("Checked operation selectors for " + checkedRoutes + " resource templates.");
+    }
+}

--- a/tests/OniMcp.Core.Tests/README.md
+++ b/tests/OniMcp.Core.Tests/README.md
@@ -1,0 +1,17 @@
+# OniMcp core regression checks
+
+Run with the .NET 10 SDK; an ONI installation is unnecessary:
+
+```sh
+dotnet run --project tests/OniMcp.Core.Tests/OniMcp.Core.Tests.csproj -c Release
+```
+
+The executable links the production MCP types, registries, resource routes and
+middleware. It checks JSON-RPC null fields, initialization retries, invalid tool
+arguments, visibility and metadata cache isolation, every registered static
+resource, and resource-template query overrides. Any failed group exits with code 1.
+
+Game tool factories return recording handlers, and the Unity speech overlay is
+replaced by a counter. These checks verify dispatch and protocol behavior; game
+assembly compatibility, actual game reads and Unity rendering still require a
+full mod build and an in-game smoke test.

--- a/tests/OniMcp.Server.Tests/GameStubs.cs
+++ b/tests/OniMcp.Server.Tests/GameStubs.cs
@@ -1,0 +1,77 @@
+// Only game/configuration boundaries are stubbed. Every Server implementation and
+// protocol type is compiled from production source, including HttpListener transport.
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using OniMcp.Core;
+
+namespace UnityEngine
+{
+    public class MonoBehaviour
+    {
+        protected object gameObject { get; } = new object();
+        protected static void Destroy(object value) { }
+        protected static void DontDestroyOnLoad(object value) { }
+    }
+}
+
+namespace OniMcp.Support
+{
+    public static class OniMcpLog
+    {
+        public static void Debug(string message) { }
+        public static void Warning(string message) { }
+        public static void Error(string message) { System.Console.Error.WriteLine(message); }
+    }
+}
+
+namespace OniMcp.Config
+{
+    public sealed class OniMcpOptions
+    {
+        public static OniMcpOptions Current { get; private set; } = new OniMcpOptions();
+        public static void Save(OniMcpOptions options) { Current = options; }
+        public int SecurityMigrationVersion { get; set; }
+        public string Host { get; set; } = "127.0.0.1";
+        public int Port { get; set; }
+        public bool AuthEnabled { get; set; }
+        public string AuthToken { get; set; }
+        public bool GlobalAutoDisinfectDisabled { get; set; }
+        public bool ScreenshotCleanupEnabled { get; set; }
+        public int ScreenshotRetentionMinutes { get; set; }
+        public int ScreenshotMaxFiles { get; set; }
+        public string EndpointUrl => "http://" + Host + ":" + Port + "/mcp/";
+        public IEnumerable<string> ListenPrefixes => new[] { "http://" + Host + ":" + Port + "/" };
+    }
+}
+
+namespace OniMcp.Tools
+{
+    public static class GameRestartCoordinator { public static void EnsureIntentConsumerStarted() { } }
+    public static class CameraTools { public static void CleanupTemporaryScreenshots() { } }
+    public static class WorldEditorTools
+    {
+        public static string ReadFileDirectly(string path) => "test";
+        public static object BuildBrowserListing(string path, string endpoint, string version) => new JObject();
+    }
+    public static class WorldEditor
+    {
+        public static string LatestScreenshotPath() => null;
+        public static string ScreenshotPathForFile(string file) => null;
+    }
+    public static class OniToolRegistry
+    {
+        public static int Calls;
+        public static List<McpToolInfo> GetToolInfos() => new List<McpToolInfo>();
+        public static CallToolResult CallTool(string name, JObject arguments)
+        {
+            Calls++;
+            return CallToolResult.Text("ok");
+        }
+    }
+    public static class OniResourceRegistry
+    {
+        public static List<McpResourceInfo> GetResourceInfos() => new List<McpResourceInfo>();
+        public static List<McpResourceTemplateInfo> GetResourceTemplateInfos() => new List<McpResourceTemplateInfo>();
+        public static ReadResourceResult ReadResource(string uri) => null;
+    }
+}

--- a/tests/OniMcp.Server.Tests/OniMcp.Server.Tests.csproj
+++ b/tests/OniMcp.Server.Tests/OniMcp.Server.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="GameStubs.cs" />
+    <Compile Include="../../mods/OniMcp/Server/*.cs" Link="Server/%(Filename)%(Extension)" />
+    <Compile Include="../../mods/OniMcp/Core/*.cs" Link="Core/%(Filename)%(Extension)" />
+    <Compile Include="../../mods/OniMcp/Support/McpJsonUtil.cs" Link="Support/McpJsonUtil.cs" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/tests/OniMcp.Server.Tests/Program.cs
+++ b/tests/OniMcp.Server.Tests/Program.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using OniMcp.Config;
+using OniMcp.Core;
+using OniMcp.Server;
+using OniMcp.Tools;
+
+internal static class Program
+{
+    private static int _passed;
+    private static MainThreadBridge _bridge;
+
+    private static void Main()
+    {
+        Check("missing main-thread bridge never executes inline", () =>
+        {
+            bool called = false;
+            Throws<InvalidOperationException>(() => MainThreadBridge.Invoke(() => called = true));
+            Throws<InvalidOperationException>(() => MainThreadBridge.Enqueue(() => called = true));
+            Assert(!called, "An uninitialized bridge executed game code");
+        });
+        _bridge = new MainThreadBridge();
+        Invoke(_bridge, "Awake");
+        try
+        {
+            Check("main-thread invocation preserves result and exception", () =>
+            {
+                Assert(MainThreadBridge.Invoke(() => 42) == 42, "Inline return value");
+                var expected = new InvalidOperationException("expected");
+                var invocation = new MainThreadInvocation<int>(() => { throw expected; });
+                invocation.Execute();
+                Assert(ReferenceEquals(expected, Throws<InvalidOperationException>(() => invocation.Wait(1000))), "Exception identity was lost");
+            });
+            Check("queued invocation is cancelled after timeout", () =>
+            {
+                bool called = false;
+                Task.Run(() => Throws<TimeoutException>(() => MainThreadBridge.Invoke(() => called = true, 10))).GetAwaiter().GetResult();
+                Invoke(_bridge, "Update");
+                Assert(!called, "Timed-out queued game action still executed");
+            });
+            Check("in-flight invocation completes safely after timeout", () =>
+            {
+                using (var started = new ManualResetEventSlim())
+                using (var release = new ManualResetEventSlim())
+                {
+                    var invocation = new MainThreadInvocation<int>(() => { started.Set(); release.Wait(); return 9; });
+                    var work = Task.Run(invocation.Execute);
+                    Assert(started.Wait(1000), "Worker did not start");
+                    try { Throws<TimeoutException>(() => invocation.Wait(0)); }
+                    finally { release.Set(); }
+                    Assert(work.Wait(1000), "Completion failed after caller timed out");
+                    Assert(invocation.Wait(0) == 9, "Completion result lost");
+                }
+            });
+            Check("queued worker receives original result", () =>
+            {
+                var work = Task.Run(() => MainThreadBridge.Invoke(() => 42));
+                PumpUntil(work);
+                Assert(work.Result == 42, "Queued return value");
+            });
+            Check("negative timeout is rejected before queuing", () =>
+                Throws<ArgumentOutOfRangeException>(() => MainThreadBridge.Invoke(() => 1, -2)));
+            Check("closed session wakes all readers and rejects enqueue", () =>
+            {
+                var session = new McpSession();
+                using (var entered = new CountdownEvent(2))
+                {
+                    var readers = Enumerable.Range(0, 2).Select(_ => Task.Run(() =>
+                    {
+                        entered.Signal();
+                        session.WaitForOutbound(10000);
+                    })).ToArray();
+                    Assert(entered.Wait(1000), "Readers did not start");
+                    session.Close();
+                    Assert(Task.WaitAll(readers, 1000), "Session close did not wake every SSE reader");
+                    Assert(!session.EnqueueOutbound(new JObject()), "Closed queue accepted a message");
+                }
+            });
+            Check("session queue is bounded and remains FIFO", () =>
+            {
+                var session = new McpSession();
+                for (int i = 0; i < McpSession.MaxQueuedOutboundMessages; i++)
+                    Assert(session.EnqueueOutbound(new JObject { ["id"] = i }), "Queue rejected available capacity");
+                Assert(!session.EnqueueOutbound(new JObject()), "Unbounded session queue");
+                Assert((int)session.TryDequeueOutbound()["id"] == 0, "Oldest message lost");
+                session.Close();
+                Assert(session.QueuedOutboundCount == 0, "Closed session retained messages");
+            });
+            Check("body limit covers declared and chunked UTF-8 bytes", () =>
+            {
+                using (var body = new MemoryStream(Encoding.UTF8.GetBytes("你好")))
+                {
+                    Assert(HttpRequestBody.Read(body, Encoding.UTF8, -1, 6) == "你好", "Exact byte limit failed");
+                    body.Position = 0;
+                    Throws<RequestBodyTooLargeException>(() => HttpRequestBody.Read(body, Encoding.UTF8, -1, 5));
+                    body.Position = 0;
+                    Throws<RequestBodyTooLargeException>(() => HttpRequestBody.Read(body, Encoding.UTF8, 6, 5));
+                    Assert(body.Position == 0, "Oversized Content-Length was read");
+                }
+            });
+            Check("settings form preserves encoded plus and literal equals", () =>
+            {
+                var form = (Dictionary<string, string>)InvokeStatic(typeof(McpHttpServer), "ParseQueryString", "?token=a%2Bb==&space=hello+world&flag&empty=&token2=%252B&&");
+                Assert(form["token"] == "a+b==", "Authentication token was corrupted");
+                Assert(form["space"] == "hello world" && form["flag"] == "" && form["empty"] == "", "Form decoding failed");
+                Assert(form["token2"] == "%2B" && !form.ContainsKey(""), "Form decoded twice or retained empty key");
+            });
+            Check("tasks are isolated by session and cancellation prevents execution", TestTaskIsolation);
+            TestHttpTransport();
+            Check("bridge destruction wakes an infinite pending invocation", () =>
+            {
+                bool called = false;
+                var work = Task.Run(() => Throws<InvalidOperationException>(() => MainThreadBridge.Invoke(() => called = true, Timeout.Infinite)));
+                var queueLock = typeof(MainThreadBridge).GetField("_queueLock", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(_bridge);
+                var cancellations = (HashSet<Action>)typeof(MainThreadBridge).GetField("_pendingCancellations", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(_bridge);
+                Assert(SpinWait.SpinUntil(() => { lock (queueLock) return cancellations.Count > 0; }, 1000), "Invocation was never queued");
+                Invoke(_bridge, "OnDestroy");
+                Assert(work.Wait(1000) && !called, "Destroyed bridge left caller blocked or executed game code");
+            });
+            Check("delayed settings restart survives bridge destruction", () =>
+            {
+                InvokeStatic(typeof(McpHttpServer), "ScheduleSettingsRestartAfterResponse");
+                // The callback runs after 250 ms; an escaping ThreadPool exception terminates this process.
+                Thread.Sleep(400);
+            });
+        }
+        finally { Invoke(_bridge, "OnDestroy"); }
+        Console.WriteLine("PASS: " + _passed + " OniMcp Server regressions (production server sources; game boundaries stubbed).");
+    }
+
+    private static void TestTaskIsolation()
+    {
+        var server = new McpHttpServer();
+        typeof(McpHttpServer).GetField("_running", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(server, true);
+        var sessions = (Dictionary<string, McpSession>)typeof(McpHttpServer).GetField("_sessions", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(server);
+        sessions["owner"] = new McpSession { Id = "owner" };
+        var created = (CreateTaskResult)Process(server, "tools/call", "owner", new JObject
+        {
+            ["name"] = "test", ["task"] = new JObject()
+        });
+        var taskId = new JObject { ["taskId"] = created.Task.TaskId };
+        Assert(((ListTasksResult)Process(server, "tasks/list", "other")).Tasks.Count == 0, "Foreign task leaked through list");
+        foreach (var method in new[] { "tasks/get", "tasks/result", "tasks/cancel" })
+            Assert(Process(server, method, "other", taskId) is JsonRpcResponse, "Foreign task accessible through " + method);
+        Assert(((ListTasksResult)Process(server, "tasks/list", "owner")).Tasks.Count == 1, "Owner cannot see task");
+        Assert(((McpTaskInfo)Process(server, "tasks/get", "owner", taskId)).Status == "working", "Foreign cancellation changed task");
+        Assert(((McpTaskInfo)Process(server, "tasks/cancel", "owner", taskId)).Status == "cancelled", "Owner cancellation failed");
+        int calls = OniToolRegistry.Calls;
+        Invoke(_bridge, "Update");
+        Assert(OniToolRegistry.Calls == calls, "Cancelled task executed");
+    }
+
+    private static void TestHttpTransport()
+    {
+        var portProbe = new TcpListener(IPAddress.Loopback, 0);
+        portProbe.Start();
+        int port = ((IPEndPoint)portProbe.LocalEndpoint).Port;
+        portProbe.Stop();
+        OniMcpOptions.Save(new OniMcpOptions { Port = port });
+        var server = new McpHttpServer();
+        server.StartServer();
+        using (var client = new HttpClient { BaseAddress = new Uri(OniMcpOptions.Current.EndpointUrl), Timeout = TimeSpan.FromSeconds(5) })
+        {
+            try
+            {
+                Check("HTTP initialize rejects malformed requests without allocating sessions", () =>
+                {
+                    foreach (var request in new[] {
+                        "{\"method\":\"initialize\",\"id\":1,\"params\":{\"protocolVersion\":\"2025-11-25\"}}",
+                        "{\"jsonrpc\":\"2.0\",\"method\":42,\"id\":1}",
+                        "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":{},\"params\":{\"protocolVersion\":\"2025-11-25\"}}",
+                        "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1,\"params\":{\"protocolVersion\":\"invalid\"}}",
+                        "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1,\"params\":{\"protocolVersion\":{}}}",
+                        "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\"}}"
+                    })
+                    using (var response = Post(client, request))
+                        Assert(ReadJson(response)["error"] != null, "Malformed initialization succeeded");
+                    Assert(server.GetSessionSummaries().Count == 0, "Rejected initialize leaked sessions");
+                });
+                string initialize = "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1,\"params\":{\"protocolVersion\":\"2025-11-25\"}}";
+                Check("HTTP initialize rejects a client-chosen unknown session id", () =>
+                {
+                    using (var response = Post(client, initialize, "forged"))
+                        Assert(response.StatusCode == HttpStatusCode.NotFound, "Unknown session was accepted");
+                    Assert(server.GetSessionSummaries().Count == 0, "Unknown id allocated a session");
+                });
+                string sessionId;
+                using (var response = Post(client, initialize))
+                {
+                    Assert(ReadJson(response)["result"] != null, "Valid initialize failed");
+                    sessionId = response.Headers.GetValues("Mcp-Session-Id").Single();
+                }
+                Check("HTTP explicit null id returns a response", () =>
+                {
+                    using (var response = Post(client, "{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"id\":null}", sessionId))
+                    {
+                        Assert(response.StatusCode == HttpStatusCode.OK, "Null id was treated as notification");
+                        var json = ReadJson(response);
+                        Assert(json.Property("id") != null && json["result"] != null, "Null-id response envelope incomplete");
+                    }
+                });
+                Check("HTTP delete prevents session resurrection and removes pending tasks", () =>
+                {
+                    Process(server, "tools/call", sessionId, new JObject { ["name"] = "test", ["task"] = new JObject() });
+                    using (var request = new HttpRequestMessage(HttpMethod.Delete, ""))
+                    {
+                        request.Headers.Add("Mcp-Session-Id", sessionId);
+                        using (var response = client.SendAsync(request).GetAwaiter().GetResult())
+                            Assert(response.StatusCode == HttpStatusCode.NoContent, "Delete failed");
+                    }
+                    int calls = OniToolRegistry.Calls;
+                    Invoke(_bridge, "Update");
+                    Assert(OniToolRegistry.Calls == calls, "Deleted session task still executed");
+                    Assert(((ListTasksResult)Process(server, "tasks/list", sessionId)).Tasks.Count == 0, "Deleted session retained tasks");
+                    var rejected = Throws<TargetInvocationException>(() => Process(server, "tools/call", sessionId,
+                        new JObject { ["name"] = "test", ["task"] = new JObject() }));
+                    Assert(rejected.InnerException is InvalidOperationException, "Deleted session created a task");
+                    using (var response = Post(client, initialize, sessionId))
+                        Assert(response.StatusCode == HttpStatusCode.NotFound, "Deleted session was resurrected");
+                });
+                Check("HTTP server restarts with a working listener", () =>
+                {
+                    server.RestartServer();
+                    using (var response = Post(client, initialize))
+                        Assert(ReadJson(response)["result"] != null, "Restarted listener failed initialization");
+                    Assert(server.GetSessionSummaries().Count == 1, "Restart retained old sessions");
+                });
+            }
+            finally { server.StopServer(); }
+        }
+    }
+
+    private static object Process(McpHttpServer server, string method, string sessionId, JObject parameters = null) =>
+        Invoke(server, "ProcessMethod", new JsonRpcRequest { Id = 1, Method = method, Params = parameters }, sessionId);
+
+    private static HttpResponseMessage Post(HttpClient client, string json, string sessionId = null)
+    {
+        using (var request = new HttpRequestMessage(HttpMethod.Post, ""))
+        {
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            if (sessionId != null)
+                request.Headers.Add("Mcp-Session-Id", sessionId);
+            var work = client.SendAsync(request);
+            PumpUntil(work);
+            return work.GetAwaiter().GetResult();
+        }
+    }
+
+    private static JObject ReadJson(HttpResponseMessage response) => JObject.Parse(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
+
+    private static void PumpUntil(Task work)
+    {
+        var elapsed = Stopwatch.StartNew();
+        while (!work.IsCompleted && elapsed.ElapsedMilliseconds < 5000)
+        {
+            Invoke(_bridge, "Update");
+            Thread.Sleep(1);
+        }
+        Assert(work.IsCompleted, "Work did not finish before test deadline");
+    }
+
+    private static object Invoke(object instance, string name, params object[] arguments) =>
+        instance.GetType().GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance).Invoke(instance, arguments);
+    private static object InvokeStatic(Type type, string name, params object[] arguments) =>
+        type.GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static).Invoke(null, arguments);
+    private static void Assert(bool condition, string message) { if (!condition) throw new Exception(message); }
+    private static T Throws<T>(Action action) where T : Exception
+    {
+        try { action(); }
+        catch (T error) { return error; }
+        throw new Exception("Expected " + typeof(T).Name);
+    }
+    private static void Check(string name, Action action)
+    {
+        action();
+        _passed++;
+        Console.WriteLine("PASS " + name);
+    }
+}

--- a/tests/OniMcp.Tools.Tests/OniMcp.Tools.Tests.csproj
+++ b/tests/OniMcp.Tools.Tests/OniMcp.Tools.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <Compile Include="../../mods/OniMcp/Core/McpContentTypes.cs" Link="Source/McpContentTypes.cs" />
+    <Compile Include="../../mods/OniMcp/Support/McpJsonUtil.cs" Link="Source/McpJsonUtil.cs" />
+    <Compile Include="../../mods/OniMcp/Tools/Impl/Server/AgentProgram*.cs" Link="Source/%(Filename)%(Extension)" />
+    <Compile Include="../../mods/OniMcp/Tools/Impl/Server/ToolBatch*.cs" Link="Source/%(Filename)%(Extension)" />
+    <Compile Include="../../mods/OniMcp/Tools/WorldEditor/WorldEditorQueryTools.cs" Link="Source/WorldEditorQueryTools.cs" />
+    <Compile Include="../../mods/OniMcp/Tools/WorldEditor/WorldEditorMapEditTokenParsing.cs" Link="Source/WorldEditorMapEditTokenParsing.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/OniMcp.Tools.Tests/Program.cs
+++ b/tests/OniMcp.Tools.Tests/Program.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+using OniMcp.Core;
+using OniMcp.Tools;
+
+internal static class Program
+{
+    private static int assertions;
+    private static int calls;
+
+    private static void Main()
+    {
+        OniToolRegistry.Tools["ok"] = new McpTool
+        {
+            Name = "ok", Mode = "read", Risk = "low",
+            Handler = args => { calls++; return CallToolResult.Text("{\"value\":42}"); }
+        };
+        OniToolRegistry.Tools["fail"] = new McpTool
+        {
+            Name = "fail", Mode = "read", Risk = "low",
+            Handler = args => { calls++; return CallToolResult.Error("expected failure"); }
+        };
+        OniToolRegistry.Tools["required"] = new McpTool
+        {
+            Name = "required", Mode = "write", Risk = "low",
+            Parameters = new System.Collections.Generic.Dictionary<string, McpToolParameter>
+            {
+                ["value"] = new McpToolParameter { Required = true }
+            },
+            Handler = args => { calls++; return CallToolResult.Text("ok"); }
+        };
+        TestBatchFailures();
+        TestProgramValidation();
+        TestProgramExecution();
+        TestNumbers();
+        TestRegexBoundaries();
+        Console.WriteLine("OniMcp tools regression checks passed: " + assertions);
+    }
+
+    private static void TestBatchFailures()
+    {
+        foreach (string mode in new[] { "summary", "full", "errors" })
+        {
+            calls = 0;
+            var result = ToolBatchTools.CallMany().Handler(JObject.Parse("{calls:[{name:'ok'},{name:'fail'},{name:'ok'}],responseMode:'" + mode + "'}"));
+            var body = Body(result);
+            Check(result.IsError && calls == 3, mode + " must propagate child failure and continue by default");
+            Check((int)body["failed"] == 1 && (int)body["succeeded"] == 2 && (int)body["executed"] == 3, "batch counts");
+            if (mode == "errors")
+                Check(((JArray)body["results"]).Count == 1 && (int)body["omitted"] == 2, "errors mode keeps error details");
+        }
+
+        calls = 0;
+        var stopped = ToolBatchTools.CallMany().Handler(JObject.Parse("{calls:[{name:'fail'},{name:'ok'}],stopOnError:true}"));
+        Check(stopped.IsError && calls == 1 && (bool)Body(stopped)["stopped"], "stopOnError must stop and propagate failure");
+
+        calls = 0;
+        var invalid = ToolBatchTools.CallMany().Handler(JObject.Parse("{calls:[{name:'ok'},{name:'required',args:{value:null}}]}"));
+        Check(invalid.IsError && calls == 0, "null required input must fail before any child runs");
+        Check((string)Body(invalid)["results"][1]["missingRequired"][0] == "value", "null required input reported");
+
+        var valid = ToolBatchTools.CallMany().Handler(JObject.Parse("{calls:[{name:'required',args:{value:false}}]}"));
+        Check(!valid.IsError && calls == 1, "false is a valid present required value");
+    }
+
+    private static void TestProgramValidation()
+    {
+        string[] invalidStatements =
+        {
+            "{op:'break'}", "{op:'continue'}", "{op:'set'}",
+            "{op:'if',when:false,then:[{op:'break'}]}",
+            "{op:'if',when:true,then:{op:'return'}}",
+            "{op:'if',when:true,then:[],else:{op:'return'}}",
+            "{op:'call',tool:'ok',args:[]}",
+            "{op:'call',tool:'ok',arguments:'malformed'}",
+            "{op:'while',when:false,do:{op:'break'}}"
+        };
+        foreach (string statement in invalidStatements)
+        {
+            foreach (bool dryRun in new[] { true, false })
+            {
+                calls = 0;
+                var result = Run("[{op:'call',tool:'ok'}," + statement + "]", dryRun);
+                Check(result.IsError && !(bool)Body(result)["valid"], "invalid structure rejected: " + statement);
+                Check(calls == 0, "invalid program must never run earlier calls");
+            }
+        }
+
+        var loop = Run("[{op:'repeat',count:2,do:[{op:'if',when:true,then:[{op:'continue'}]}]}]", true);
+        Check(!loop.IsError, "continue nested in if inside loop is valid");
+    }
+
+    private static void TestProgramExecution()
+    {
+        calls = 0;
+        var result = Run("{vars:{sum:0},steps:[{op:'repeat',count:3,do:[{op:'set',name:'sum',value:{add:['$sum',1]}}]},{op:'return',value:'$sum'}]}");
+        Check(!result.IsError && (int)Body(result)["returnValue"] == 3, "repeat/set/return execute normally");
+
+        result = Run("[{op:'call',tool:'fail'},{op:'call',tool:'ok'}]");
+        Check(result.IsError && calls == 1, "failed call stops program");
+        calls = 0;
+        result = Run("[{op:'call',tool:'fail',continueOnError:true},{op:'call',tool:'ok',saveAs:'answer'},{op:'return',value:'$answer.value'}]");
+        Check(!result.IsError && calls == 2 && (int)Body(result)["returnValue"] == 42, "continueOnError and saved results");
+        result = Run("[{op:'while',when:true,do:[{op:'comment'}]}]");
+        Check(result.IsError && ((string)Body(result)["error"]).Contains("maxLoopIterations"), "loop execution remains bounded");
+    }
+
+    private static void TestNumbers()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            var result = Run("[{op:'return',value:{add:[1.25,2.5]}}]");
+            Check(!result.IsError && (double)Body(result)["returnValue"] == 3.75, "numeric JSON arithmetic is culture independent");
+        }
+        finally { CultureInfo.CurrentCulture = original; }
+
+        foreach (string expression in new[] { "{div:[1,0]}", "{mod:[1,0]}", "{mul:[1e308,1e308]}", "{add:['NaN',1]}", "{add:['Infinity',1]}" })
+            Check(Run("[{op:'return',value:" + expression + "}]").IsError, "non-finite arithmetic rejected: " + expression);
+        foreach (string count in new[] { "0.5", "2147483648", "-0.5" })
+            Check(Run("[{op:'repeat',count:" + count + ",do:[]}]").IsError, "invalid repeat count rejected: " + count);
+    }
+
+    private static void TestRegexBoundaries()
+    {
+        WorldEditorTools.ReadText = "First Line\nsecond line\nthird";
+        var result = WorldEditorTools.RunGrep(JObject.Parse("{query:'^first',regex:true,context:0}"));
+        Check(!result.IsError && result.Content[0].Text.Contains("0001: First Line"), "grep regex preserves ignoreCase default");
+        Check(WorldEditorTools.RunGrep(JObject.Parse("{query:'[',regex:true}")).IsError, "invalid regex returns error");
+        Check(WorldEditorTools.MatchToken("Tile@(1,2)", "Tile"), "coordinate suffix token matching preserved");
+        Check(WorldEditorTools.MatchToken("Tile", "/^Tile$/") && WorldEditorTools.MatchToken("Tile", "~^Tile$"), "map regex forms preserved");
+
+        string hostile = new string('a', 20000) + "!";
+        WorldEditorTools.ReadText = hostile;
+        var timer = Stopwatch.StartNew();
+        result = WorldEditorTools.RunGrep(JObject.Parse("{query:'^(a+)+$',regex:true}"));
+        Check(result.IsError && result.Content[0].Text.Contains("timed out"), "grep catastrophic backtracking returns a clear error");
+        Check(timer.Elapsed < TimeSpan.FromSeconds(5), "grep cannot hang the game thread indefinitely");
+        foreach (string pattern in new[] { "/^(a+)+$/", "~^(a+)+$" })
+        {
+            bool timedOut = false;
+            try { WorldEditorTools.MatchToken(hostile, pattern); }
+            catch (RegexMatchTimeoutException) { timedOut = true; }
+            Check(timedOut, "map regex propagates its timeout");
+        }
+    }
+
+    private static CallToolResult Run(string program, bool dryRun = false) => AgentProgramTools.ExecuteProgram().Handler(new JObject { ["program"] = JToken.Parse(program), ["dryRun"] = dryRun });
+    private static JObject Body(CallToolResult result) => JObject.Parse(result.Content[0].Text);
+    private static void Check(bool condition, string description)
+    {
+        assertions++;
+        if (!condition) throw new InvalidOperationException(description);
+    }
+}

--- a/tests/OniMcp.Tools.Tests/TestDoubles.cs
+++ b/tests/OniMcp.Tools.Tests/TestDoubles.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using OniMcp.Core;
+
+// Only game/registry boundaries are substituted. The batch, DSL, response types,
+// and both regex entry points are compiled directly from production source.
+namespace OniMcp.Tools
+{
+    public sealed class McpTool
+    {
+        public string Name { get; set; }
+        public string Group { get; set; }
+        public string Mode { get; set; }
+        public string Risk { get; set; }
+        public string Description { get; set; }
+        public List<string> Aliases { get; set; }
+        public List<string> Tags { get; set; }
+        public Dictionary<string, McpToolParameter> Parameters { get; set; }
+        public Func<JObject, CallToolResult> Handler { get; set; }
+    }
+
+    public sealed class McpToolParameter
+    {
+        public string Type { get; set; }
+        public string Description { get; set; }
+        public bool Required { get; set; }
+        public List<string> EnumValues { get; set; }
+    }
+
+    public static class OniToolRegistry
+    {
+        internal static readonly Dictionary<string, McpTool> Tools = new Dictionary<string, McpTool>(StringComparer.OrdinalIgnoreCase);
+        public static bool TryGetTool(string name, out McpTool tool) => Tools.TryGetValue(name, out tool);
+        public static CallToolResult CallTool(string name, JObject arguments) => Tools[name].Handler(arguments);
+    }
+
+    public static class ToolUtil
+    {
+        public static bool GetBool(JObject args, string name, bool fallback) => args[name]?.Value<bool>() ?? fallback;
+        public static int? GetInt(JObject args, string name) => args[name]?.Value<int?>();
+    }
+
+    public static class ServerTools
+    {
+        internal static bool IsServerControlDomainCall(string name, JObject args, params string[] domains)
+        {
+            McpTool tool;
+            return OniToolRegistry.TryGetTool(name, out tool) && tool.Name == "server_control"
+                && domains.Contains((args?["domain"]?.ToString() ?? "diagnostics").Trim().ToLowerInvariant());
+        }
+    }
+
+    public static partial class WorldEditorTools
+    {
+        private const string _cwd = "/active/";
+        internal static string ReadText;
+        internal static CallToolResult RunGrep(JObject args) => Grep(args);
+        internal static bool MatchToken(string actual, string pattern) => SearchTokenMatches(actual, pattern);
+        private static string NormalizePath(string path, string cwd) => string.IsNullOrEmpty(path) ? cwd : path;
+        private static string Text(JObject args, params string[] keys) => keys.Select(key => args[key]?.ToString()).FirstOrDefault(value => !string.IsNullOrEmpty(value)) ?? "";
+        private static JObject CopyPayload(JObject args) => (JObject)args.DeepClone();
+        private static CallToolResult Read(JObject args) => CallToolResult.Text(ReadText);
+        private static CallToolResult SearchGlyphs(JObject args) => throw new NotSupportedException();
+        private static List<JObject> BuildSymbolRows() => throw new NotSupportedException();
+        private static char GetUniqueChar(string id, string name) => throw new NotSupportedException();
+        private static string MapTokenPart(string token) => token;
+        private static readonly Dictionary<string, char> UniqueCharMap = new Dictionary<string, char>();
+        private sealed class MapEditCell
+        {
+            public int X { get; set; }
+            public int Y { get; set; }
+        }
+    }
+}
+
+internal enum SimHashes { TestElement }
+internal static class Assets
+{
+    internal static readonly List<TestBuildingDef> BuildingDefs = new List<TestBuildingDef>();
+}
+internal sealed class TestBuildingDef
+{
+    public string PrefabID { get; set; }
+    public string Name { get; set; }
+}


### PR DESCRIPTION
## Why
Both Mods had reproducible correctness problems in performance-sensitive and stateful paths. OniMcp could report failed batches as successful, fail registered resource reads, execute commands after a queued call timed out, or replace unreadable configuration with defaults. CycleTrim could reuse a completed path result after replacement work was discarded or rejected.

## Changes
- **CycleTrim:** invalidate stale queued/completed probe state and caches across NavGrid changes; preserve vanilla fallback for unsupported abilities and invalid cells; harden worker-count arithmetic and exception cleanup.
- **OniMcp service:** cancel timed-out queued calls, wake pending calls when the bridge is destroyed, clean up SSE/session state, enforce task ownership, bound request bodies, and validate JSON-RPC envelopes. Fix settings form decoding and delayed restart races.
- **OniMcp resources/config/tools:** dispatch resources to the registered read operation while fixing route selectors; preserve JSON-RPC null IDs/results; make configuration writes atomic; validate DSL structure before execution; propagate batch failures; bound user regex matching.
- Add source-linked C# regression projects, a shared `scripts/check_mods.py` runner, the `Mod quality` workflow, and testing/release notes. No Mod versions or releases are changed.

## Validation
[GitHub Mod quality CI](https://github.com/LIghtJUNction/OniMods/actions/runs/34191077984) **passed** for commit `9377f5a9479887b297f16ef393b0d241ebf6192a`.

`python3 scripts/check_mods.py --dotnet /tmp/onimods-dotnet/dotnet`: **23/23 checks passed** with warnings treated as errors:
- 18 existing Python source contracts.
- CycleTrim: 34 policy regression groups, including 6 new groups.
- OniMcp Config: 8 regression cases, including concurrent file access and failed reload/save handling.
- OniMcp Core: 11 groups covering 126 static resource routes and 108 templates, including query override attempts.
- OniMcp Server: 18 regressions, including real local HttpListener/HttpClient requests.
- OniMcp Tools: 69 assertions for batch, DSL, numeric and regex behavior.

The new CycleTrim tests failed in 5 groups when linked to the original Core implementation. Original OniMcp source also reproduced incorrect batch error reporting, invalid DSL acceptance and locale-sensitive numeric failures; the original regex exceeded the controlled test deadline. Independent reviews covered CycleTrim and OniMcp execution/lifecycle changes. `git diff --check` passed.

## Remaining integration checks
The environment does not include game assemblies, so full net48 Mod builds, Harmony target/binary checks, packaging checks, Unity behavior and in-game FPS were **not verified**. The console tests link production source but use stubs at game boundaries; they are not a replacement for those checks. Reproduction commands are in `docs/mod-testing.md`.

A running Unity operation cannot be interrupted safely; the timeout fix prevents operations that have not started from executing later.
